### PR TITLE
Persistent counters (#150)

### DIFF
--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -100,7 +100,7 @@ class PiApplication(object):
         self.previous_picture_file = None
 
         self.count = Counters(self._config.join_path("counters.pickle"),
-                              taken=0, printed=0, duplicated=0, forgotten=0)
+                              taken=0, printed=0, remaining_duplicates=0, forgotten=0)
 
         self.camera = camera.get_camera(config.getint('CAMERA', 'iso'),
                                         config.gettyped('CAMERA', 'resolution'),

--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -100,7 +100,8 @@ class PiApplication(object):
         self.previous_picture_file = None
 
         self.count = Counters(self._config.join_path("counters.pickle"),
-                              taken=0, printed=0, remaining_duplicates=0, forgotten=0)
+                              taken=0, printed=0, forgotten=0,
+                              remaining_duplicates=self._config.getint('PRINTER', 'max_duplicates'))
 
         self.camera = camera.get_camera(config.getint('CAMERA', 'iso'),
                                         config.gettyped('CAMERA', 'resolution'),

--- a/pibooth/config/menu.py
+++ b/pibooth/config/menu.py
@@ -76,7 +76,7 @@ def _counters(counters):
     """
     long_name = max(counters.names(), key=len)
     pattern = '{:.<' + str(max(len(long_name) + 2, 25)) + '} {: >4}'
-    return [pattern.format(name.capitalize(), counters[name]) for name in counters]
+    return [pattern.format(name.replace("_", " ").capitalize(), counters[name]) for name in counters]
 
 
 class PiConfigMenu(object):

--- a/pibooth/config/menu.py
+++ b/pibooth/config/menu.py
@@ -28,24 +28,36 @@ THEME_WHITE = pgm.themes.Theme(
     widget_font_color=(0, 0, 0),
 )
 
-SUBTHEME_WHITE = THEME_WHITE.copy()
-SUBTHEME_WHITE.background_color = (255, 255, 255)
-SUBTHEME_WHITE.scrollbar_slider_color = (252, 151, 0)
-SUBTHEME_WHITE.selection_color = (241, 125, 1)
-SUBTHEME_WHITE.title_background_color = (252, 151, 0)
-SUBTHEME_WHITE.widget_alignment = pgm.locals.ALIGN_LEFT
-SUBTHEME_WHITE.widget_margin = (40, 10)
-SUBTHEME_WHITE.widget_font_size = 18
+SUBTHEME1_WHITE = THEME_WHITE.copy()
+SUBTHEME1_WHITE.background_color = (255, 255, 255)
+SUBTHEME1_WHITE.scrollbar_slider_color = (252, 151, 0)
+SUBTHEME1_WHITE.selection_color = (241, 125, 1)
+SUBTHEME1_WHITE.title_background_color = (252, 151, 0)
+SUBTHEME1_WHITE.widget_alignment = pgm.locals.ALIGN_LEFT
+SUBTHEME1_WHITE.widget_margin = (40, 10)
+SUBTHEME1_WHITE.widget_font_size = 18
+
+SUBTHEME2_WHITE = SUBTHEME1_WHITE.copy()
+SUBTHEME2_WHITE.scrollbar_slider_color = (152, 43, 175)
+SUBTHEME2_WHITE.selection_color = (120, 36, 161)
+SUBTHEME2_WHITE.title_background_color = (152, 43, 175)
+SUBTHEME2_WHITE.widget_alignment = pgm.locals.ALIGN_CENTER
+SUBTHEME2_WHITE.widget_margin = (0, 20)
 
 THEME_DARK = THEME_WHITE.copy()
 THEME_DARK.background_color = (40, 41, 35)
 THEME_DARK.cursor_color = (255, 255, 255)
 THEME_DARK.widget_font_color = (255, 255, 255)
 
-SUBTHEME_DARK = SUBTHEME_WHITE.copy()
-SUBTHEME_DARK.background_color = (40, 41, 35)
-SUBTHEME_DARK.cursor_color = (255, 255, 255)
-SUBTHEME_DARK.widget_font_color = (255, 255, 255)
+SUBTHEME1_DARK = SUBTHEME1_WHITE.copy()
+SUBTHEME1_DARK.background_color = (40, 41, 35)
+SUBTHEME1_DARK.cursor_color = (255, 255, 255)
+SUBTHEME1_DARK.widget_font_color = (255, 255, 255)
+
+SUBTHEME2_DARK = SUBTHEME2_WHITE.copy()
+SUBTHEME2_DARK.background_color = (40, 41, 35)
+SUBTHEME2_DARK.cursor_color = (255, 255, 255)
+SUBTHEME2_DARK.widget_font_color = (255, 255, 255)
 
 
 def _find(choices, value):
@@ -59,11 +71,20 @@ def _find(choices, value):
     return 0
 
 
+def _counters(counters):
+    """Return the formatted text for counters.
+    """
+    long_name = max(counters.names(), key=len)
+    pattern = '{:.<' + str(max(len(long_name) + 2, 25)) + '} {: >4}'
+    return [pattern.format(name.capitalize(), getattr(counters, name)) for name in counters.names()]
+
+
 class PiConfigMenu(object):
 
-    def __init__(self, window, config, onclose=None):
+    def __init__(self, window, config, counters, onclose=None):
         self.win = window
         self.cfg = config
+        self.count = counters
         self._main_menu = None
         self._close_callback = onclose
 
@@ -93,7 +114,7 @@ class PiConfigMenu(object):
         menu = pgm.Menu(self.size[1],
                         self.size[0],
                         section.capitalize(),
-                        theme=SUBTHEME_DARK)
+                        theme=SUBTHEME1_DARK)
 
         for name, option in DEFAULT[section].items():
             if option[2]:
@@ -126,6 +147,24 @@ class PiConfigMenu(object):
                                       section=section,
                                       option=name)
 
+        if section.lower() == 'general':
+            menu.add_vertical_margin(40)
+            menu.add_button("View counters",
+                            self._build_submenu_counters("Counters"),
+                            margin=(self.size[0] // 2 - 100, 0))
+
+        return menu
+
+    def _build_submenu_counters(self, title):
+        menu = pgm.Menu(self.size[1],
+                        self.size[0],
+                        title.capitalize(),
+                        theme=SUBTHEME2_DARK)
+        labels = []
+        for text in _counters(self.count):
+            labels.append(menu.add_label(text))
+        menu.add_vertical_margin(40)
+        menu.add_button("Reset all", self._on_reset_counters, labels)
         return menu
 
     def _on_selector_changed(self, value, **kwargs):
@@ -145,6 +184,13 @@ class PiConfigMenu(object):
         """
         if self._main_menu.is_enabled():  # Menu may have been closed
             self.cfg.set(kwargs['section'], kwargs['option'], str(value))
+
+    def _on_reset_counters(self, labels):
+        """Called when the counters are reset.
+        """
+        self.count.reset()
+        for label, text in zip(labels, _counters(self.count)):
+            label.set_title(text)
 
     def _on_close(self):
         """Called when the menu is closed.

--- a/pibooth/config/menu.py
+++ b/pibooth/config/menu.py
@@ -76,7 +76,7 @@ def _counters(counters):
     """
     long_name = max(counters.names(), key=len)
     pattern = '{:.<' + str(max(len(long_name) + 2, 25)) + '} {: >4}'
-    return [pattern.format(name.capitalize(), getattr(counters, name)) for name in counters.names()]
+    return [pattern.format(name.capitalize(), counters[name]) for name in counters]
 
 
 class PiConfigMenu(object):

--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -315,6 +315,15 @@ class PiConfigParser(ConfigParser):
             LOGGER.info("Remove the auto-startup file in '%s'", dirname)
             os.remove(filename)
 
+    def join_path(self, *names):
+        """Return the directory path of the configuration file
+        and join it the given names.
+
+        :param names: names to join to the directory path
+        :type names: str
+        """
+        return osp.join(osp.dirname(self.filename), *names)
+
     def add_option(self, section, option, default, description, menu_name=None, menu_choices=None):
         """Add a new option to the configuration and defines its default value.
 

--- a/pibooth/counters.py
+++ b/pibooth/counters.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+import pickle
+import os.path as osp
+
+
+class Counters(object):
+
+    def __init__(self, filename='', **kwargs):
+        self.data = kwargs.copy()
+        self.default = kwargs
+        self.filename = osp.abspath(osp.expanduser(filename))
+        if osp.isfile(self.filename):
+            self.load()
+
+    def __getattr__(self, name):
+        """Called only when an attribute does not exist.
+        """
+        if name not in self.data:
+            raise AttributeError("No counter with name '{}'".format(name))
+        return self.data[name]
+
+    def __setattr__(self, name, value):
+        """Called each time a attribute is set.
+        """
+        if name != 'data' and name in self.data:
+            self.data[name] = value
+            self.save()
+        else:
+            super(Counters, self).__setattr__(name, value)
+
+    def names(self):
+        """Return the list of counters.
+        """
+        return [key for key in self.data]
+
+    def load(self):
+        """Load the saved counters.
+        """
+        with open(self.filename, 'rb') as fp:
+            self.data.update(pickle.load(fp))
+
+    def reset(self):
+        """Reset all counters.
+        """
+        self.data = self.default.copy()
+        self.save()
+
+    def save(self):
+        """Save the current counters in a file.
+        """
+        with open(self.filename, 'wb') as fp:
+            pickle.dump(self.data, fp, pickle.HIGHEST_PROTOCOL)

--- a/pibooth/counters.py
+++ b/pibooth/counters.py
@@ -13,6 +13,16 @@ class Counters(object):
         if osp.isfile(self.filename):
             self.load()
 
+    def __iter__(self):
+        """Iterate over counters names.
+        """
+        return iter(self.data)
+
+    def __getitem__(self, name):
+        """Get value from counter name.
+        """
+        return self.__getattr__(name)
+
     def __getattr__(self, name):
         """Called only when an attribute does not exist.
         """
@@ -21,7 +31,7 @@ class Counters(object):
         return self.data[name]
 
     def __setattr__(self, name, value):
-        """Called each time a attribute is set.
+        """Called each time an attribute is set.
         """
         if name != 'data' and name in self.data:
             self.data[name] = value

--- a/pibooth/plugins/__init__.py
+++ b/pibooth/plugins/__init__.py
@@ -60,7 +60,7 @@ def list_plugin_names(plugin_manager):
     """
     values = []
     for plugin in plugin_manager.get_plugins():
-        # The internal plugins are classes, we don't want to include
+        # The core plugins are classes, we don't want to include
         # them here, thus we take only the modules objects.
         if inspect.ismodule(plugin):
             name = get_plugin_name(plugin_manager, plugin)

--- a/pibooth/plugins/lights_plugin.py
+++ b/pibooth/plugins/lights_plugin.py
@@ -13,18 +13,18 @@ class LightsPlugin(object):
         self.blink_time = 0.3
 
     @pibooth.hookimpl
-    def state_wait_enter(self, cfg, app):
+    def state_wait_enter(self, app):
         if app.previous_picture_file and app.printer.is_available()\
-                and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'):
+                and app.count.remaining_duplicates > 0:
             app.leds.blink(on_time=self.blink_time, off_time=self.blink_time)
         else:
             app.leds.capture.blink(on_time=self.blink_time, off_time=self.blink_time)
             app.leds.printer.off()
 
     @pibooth.hookimpl
-    def state_wait_do(self, cfg, app, events):
+    def state_wait_do(self, app, events):
         if app.find_print_event(events) and app.previous_picture_file and app.printer.is_available():
-            if app.count.duplicated >= cfg.getint('PRINTER', 'max_duplicates'):
+            if app.count.remaining_duplicates <= 0:
                 app.leds.printer.off()
             else:
                 app.leds.printer.on()

--- a/pibooth/plugins/lights_plugin.py
+++ b/pibooth/plugins/lights_plugin.py
@@ -15,7 +15,7 @@ class LightsPlugin(object):
     @pibooth.hookimpl
     def state_wait_enter(self, cfg, app):
         if app.previous_picture_file and app.printer.is_available()\
-                and app.nbr_duplicates < cfg.getint('PRINTER', 'max_duplicates'):
+                and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'):
             app.leds.blink(on_time=self.blink_time, off_time=self.blink_time)
         else:
             app.leds.capture.blink(on_time=self.blink_time, off_time=self.blink_time)
@@ -24,7 +24,7 @@ class LightsPlugin(object):
     @pibooth.hookimpl
     def state_wait_do(self, cfg, app, events):
         if app.find_print_event(events) and app.previous_picture_file and app.printer.is_available():
-            if app.nbr_duplicates >= cfg.getint('PRINTER', 'max_duplicates'):
+            if app.count.duplicated >= cfg.getint('PRINTER', 'max_duplicates'):
                 app.leds.printer.off()
             else:
                 app.leds.printer.on()

--- a/pibooth/plugins/picture_plugin.py
+++ b/pibooth/plugins/picture_plugin.py
@@ -149,4 +149,4 @@ class PicturePlugin(object):
 
             # Deactivate the print function for the backuped picture
             # as we don't known how many times it has already been printed
-            app.count.duplicated = cfg.getint('PRINTER', 'max_duplicates') + 1
+            app.count.remaining_duplicates = 0

--- a/pibooth/plugins/picture_plugin.py
+++ b/pibooth/plugins/picture_plugin.py
@@ -128,6 +128,10 @@ class PicturePlugin(object):
                     self.factory_pool.add(factory)
 
     @pibooth.hookimpl
+    def state_processing_exit(self, app):
+        app.count.taken += 1  # Do it here because 'print' state can be skipped
+
+    @pibooth.hookimpl
     def state_print_do(self, cfg, app, events):
         if app.find_capture_event(events):
 
@@ -140,8 +144,9 @@ class PicturePlugin(object):
                     os.rename(osp.join(savedir, app.picture_filename), osp.join(forgetdir, app.picture_filename))
 
             self._reset_vars(app)
+            app.count.forgotten += 1
             app.previous_picture = self.second_previous_picture
 
             # Deactivate the print function for the backuped picture
             # as we don't known how many times it has already been printed
-            app.nbr_duplicates = cfg.getint('PRINTER', 'max_duplicates') + 1
+            app.count.duplicated = cfg.getint('PRINTER', 'max_duplicates') + 1

--- a/pibooth/plugins/printer_plugin.py
+++ b/pibooth/plugins/printer_plugin.py
@@ -20,31 +20,32 @@ class PrinterPlugin(object):
     def state_failsafe_enter(self, app):
         """Reset variables set in this plugin.
         """
-        app.nbr_duplicates = 0
+        app.count.duplicated = 0
 
     @pibooth.hookimpl
     def state_wait_do(self, cfg, app, events):
         if app.find_print_event(events) and app.previous_picture_file and app.printer.is_installed():
 
-            if app.nbr_duplicates >= cfg.getint('PRINTER', 'max_duplicates'):
+            if app.count.duplicated >= cfg.getint('PRINTER', 'max_duplicates'):
                 LOGGER.warning("Too many duplicates sent to the printer (%s max)",
                                cfg.getint('PRINTER', 'max_duplicates'))
                 return
 
             elif not app.printer.is_available():
-                LOGGER.warning("Maximum number of printed pages reached (%s/%s max)", app.printer.nbr_printed,
+                LOGGER.warning("Maximum number of printed pages reached (%s/%s max)", app.count.printed,
                                cfg.getint('PRINTER', 'max_pages'))
                 return
 
             with timeit("Send final picture to printer"):
                 app.printer.print_file(app.previous_picture_file,
                                        cfg.getint('PRINTER', 'pictures_per_page'))
+                app.count.printed += 1
 
-            app.nbr_duplicates += 1
+            app.count.duplicated += 1
 
     @pibooth.hookimpl
     def state_processing_exit(self, app):
-        app.nbr_duplicates = 0
+        app.count.duplicated = 0   # Do it here because 'print' state can be skipped
 
     @pibooth.hookimpl
     def state_print_do(self, cfg, app, events):
@@ -53,5 +54,6 @@ class PrinterPlugin(object):
             with timeit("Send final picture to printer"):
                 app.printer.print_file(app.previous_picture_file,
                                        cfg.getint('PRINTER', 'pictures_per_page'))
+                app.count.printed += 1
 
-            app.nbr_duplicates += 1
+            app.count.duplicated += 1

--- a/pibooth/plugins/printer_plugin.py
+++ b/pibooth/plugins/printer_plugin.py
@@ -17,16 +17,16 @@ class PrinterPlugin(object):
         app.printer.quit()
 
     @pibooth.hookimpl
-    def state_failsafe_enter(self, app):
+    def state_failsafe_enter(self, cfg, app):
         """Reset variables set in this plugin.
         """
-        app.count.remaining_duplicates = 0
+        app.count.remaining_duplicates = cfg.getint('PRINTER', 'max_duplicates')
 
     @pibooth.hookimpl
     def state_wait_do(self, cfg, app, events):
         if app.find_print_event(events) and app.previous_picture_file and app.printer.is_installed():
 
-            if app.count.remaining_duplicates < 0:
+            if app.count.remaining_duplicates <= 0:
                 LOGGER.warning("Too many duplicates sent to the printer (%s max)",
                                cfg.getint('PRINTER', 'max_duplicates'))
                 return
@@ -46,7 +46,6 @@ class PrinterPlugin(object):
     @pibooth.hookimpl
     def state_processing_exit(self, cfg, app):
         app.count.remaining_duplicates = cfg.getint('PRINTER', 'max_duplicates')
-        # Do it here because 'print' state can be skipped
 
     @pibooth.hookimpl
     def state_print_do(self, cfg, app, events):

--- a/pibooth/plugins/view_plugin.py
+++ b/pibooth/plugins/view_plugin.py
@@ -46,16 +46,16 @@ class ViewPlugin(object):
             previous_picture = app.previous_picture
 
         win.show_intro(previous_picture, app.printer.is_available()
-                       and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'))
+                       and app.count.remaining_duplicates > 0)
         if app.printer.is_installed():
             win.set_print_number(len(app.printer.get_all_tasks()), not app.printer.is_available())
 
     @pibooth.hookimpl
-    def state_wait_do(self, cfg, app, win, events):
+    def state_wait_do(self, app, win, events):
         if app.previous_animated and self.animated_frame_timer.is_timeout():
             previous_picture = next(app.previous_animated)
             win.show_intro(previous_picture, app.printer.is_available()
-                           and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'))
+                           and app.count.remaining_duplicates > 0)
             self.animated_frame_timer.start()
         else:
             previous_picture = app.previous_picture
@@ -66,7 +66,7 @@ class ViewPlugin(object):
 
         if app.find_print_event(events) or (win.get_image() and not previous_picture):
             win.show_intro(previous_picture, app.printer.is_available()
-                           and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'))
+                           and app.count.remaining_duplicates > 0)
 
     @pibooth.hookimpl
     def state_wait_validate(self, app, events):
@@ -131,7 +131,7 @@ class ViewPlugin(object):
     @pibooth.hookimpl
     def state_processing_validate(self, cfg, app):
         if app.printer.is_available() and cfg.getfloat('PRINTER', 'printer_delay') > 0\
-                and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'):
+                and app.count.remaining_duplicates > 0:
             return 'print'
         return 'finish'  # Can not print
 

--- a/pibooth/plugins/view_plugin.py
+++ b/pibooth/plugins/view_plugin.py
@@ -46,7 +46,7 @@ class ViewPlugin(object):
             previous_picture = app.previous_picture
 
         win.show_intro(previous_picture, app.printer.is_available()
-                       and app.nbr_duplicates < cfg.getint('PRINTER', 'max_duplicates'))
+                       and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'))
         if app.printer.is_installed():
             win.set_print_number(len(app.printer.get_all_tasks()), not app.printer.is_available())
 
@@ -55,7 +55,7 @@ class ViewPlugin(object):
         if app.previous_animated and self.animated_frame_timer.is_timeout():
             previous_picture = next(app.previous_animated)
             win.show_intro(previous_picture, app.printer.is_available()
-                           and app.nbr_duplicates < cfg.getint('PRINTER', 'max_duplicates'))
+                           and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'))
             self.animated_frame_timer.start()
         else:
             previous_picture = app.previous_picture
@@ -66,7 +66,7 @@ class ViewPlugin(object):
 
         if app.find_print_event(events) or (win.get_image() and not previous_picture):
             win.show_intro(previous_picture, app.printer.is_available()
-                           and app.nbr_duplicates < cfg.getint('PRINTER', 'max_duplicates'))
+                           and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'))
 
     @pibooth.hookimpl
     def state_wait_validate(self, app, events):
@@ -131,7 +131,7 @@ class ViewPlugin(object):
     @pibooth.hookimpl
     def state_processing_validate(self, cfg, app):
         if app.printer.is_available() and cfg.getfloat('PRINTER', 'printer_delay') > 0\
-                and app.nbr_duplicates < cfg.getint('PRINTER', 'max_duplicates'):
+                and app.count.duplicated < cfg.getint('PRINTER', 'max_duplicates'):
             return 'print'
         return 'finish'  # Can not print
 

--- a/pibooth/scripts/count.py
+++ b/pibooth/scripts/count.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""Script to display/update counters.
+"""
+
+import sys
+import json
+from pibooth.counters import Counters
+from pibooth.utils import configure_logging
+from pibooth.config import PiConfigParser
+from pibooth.plugins import create_plugin_manager
+
+
+def main():
+    """Application entry point.
+    """
+    configure_logging()
+    plugin_manager = create_plugin_manager()
+    config = PiConfigParser("~/.config/pibooth/pibooth.cfg", plugin_manager)
+
+    counters = Counters(config.join_path("counters.pickle"),
+                        taken=0, printed=0, duplicated=0, forgotten=0)
+
+    if '--json' in sys.argv:
+        print(json.dumps(counters.data))
+    elif '--update' in sys.argv:
+        try:
+            print("\nUpdating counters (current value in square bracket):\n")
+            for name in counters:
+                value = input(" -> {:.<18} [{:>4}] : ".format(name.capitalize(), counters[name]))
+                if value.strip():
+                    setattr(counters, name, int(value))
+        except KeyboardInterrupt:
+            pass
+        print()
+    else:
+        print("\nListing current counters:\n")
+        for name in counters:
+            print(" -> {:.<25} : {:>4}".format(name.capitalize(), counters[name]))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/pibooth/scripts/count.py
+++ b/pibooth/scripts/count.py
@@ -19,7 +19,7 @@ def main():
     config = PiConfigParser("~/.config/pibooth/pibooth.cfg", plugin_manager)
 
     counters = Counters(config.join_path("counters.pickle"),
-                        taken=0, printed=0, duplicated=0, forgotten=0)
+                        taken=0, printed=0, remaining_duplicates=0, forgotten=0)
 
     if '--json' in sys.argv:
         print(json.dumps(counters.data))

--- a/pibooth/scripts/count.py
+++ b/pibooth/scripts/count.py
@@ -19,7 +19,8 @@ def main():
     config = PiConfigParser("~/.config/pibooth/pibooth.cfg", plugin_manager)
 
     counters = Counters(config.join_path("counters.pickle"),
-                        taken=0, printed=0, remaining_duplicates=0, forgotten=0)
+                        taken=0, printed=0, forgotten=0,
+                        remaining_duplicates=config.getint('PRINTER', 'max_duplicates'))
 
     if '--json' in sys.argv:
         print(json.dumps(counters.data))

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ def main():
         },
         zip_safe=False,  # Don't install the lib as an .egg zipfile
         entry_points={'console_scripts': ["pibooth = pibooth.booth:main",
+                                          "pibooth-count = pibooth.scripts.count:main",
                                           "pibooth-diag = pibooth.scripts.diagnostic:main",
                                           "pibooth-regen = pibooth.scripts.regenerate:main"]},
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 import os
 import pytest
 from PIL import Image
+from pibooth.counters import Counters
 from pibooth.config.parser import PiConfigParser
 
 MOCKS_DIR = os.path.join(os.path.dirname(__file__), 'mocks')
@@ -36,6 +37,12 @@ def overlay_path():
 def cfg_path():
     return os.path.join(MOCKS_DIR, 'pibooth.cfg')
 
+
 @pytest.fixture(scope='session')
 def cfg(cfg_path):
     return PiConfigParser(cfg_path, None)
+
+
+@pytest.fixture
+def counters(tmpdir):
+    return Counters(str(tmpdir.join('data.pickle')), nbr_printed=0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,11 @@ import os.path as osp
 import pytest
 
 
+def test_join_path_to_config_directory(cfg):
+    assert cfg.join_path() == osp.dirname(cfg.filename)
+    assert cfg.join_path('test') == osp.join(osp.dirname(cfg.filename), 'test')
+
+
 def test_not_in_config_option(cfg):
     assert cfg.get('GENERAL', 'autostart') == 'False'
 

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+
+def test_names(counters):
+    assert len(counters.names()) == 1
+    assert 'nbr_printed' in counters.names()
+
+
+def test_set(counters):
+    assert counters.nbr_printed == 0
+    counters.nbr_printed += 2
+    assert counters.nbr_printed == 2
+
+
+def test_reset(counters):
+    counters.nbr_printed = 5
+    assert counters.nbr_printed == 5
+    counters.reset()
+    assert counters.nbr_printed == 0
+
+
+def test_invalid_counter(counters):
+    with pytest.raises(AttributeError):
+        counters.invalid
+
+
+def test_save(counters):
+    counters.nbr_printed = 5
+    counters.data['nbr_printed'] = 0
+    assert counters.nbr_printed == 0
+    counters.load()
+    assert counters.nbr_printed == 5
+    counters.reset()
+    counters.load()
+    assert counters.nbr_printed == 0

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -3,6 +3,15 @@
 import pytest
 
 
+def test_iter(counters):
+    for name in counters:
+        assert name
+
+
+def test_getitem(counters):
+    assert counters['nbr_printed'] == 0
+
+
 def test_names(counters):
     assert len(counters.names()) == 1
     assert 'nbr_printed' in counters.names()


### PR DESCRIPTION
PR fixing #150 :

- Make several counters persistent after restart
- Display counters in a dedicated sub-menu
- Counters are accessible from plugins
- Cache file is located in same folder as the config file
- Use pickle format to make saving and loading faster


<img width="599" alt="counters" src="https://user-images.githubusercontent.com/25277953/84768143-05980d80-afd4-11ea-834a-0421d6e8f676.png">
