### PR TITLE
split menu label on 2 columns if more than 5 (ie add plugins)

### DIFF
--- a/pibooth/config/menu.py
+++ b/pibooth/config/menu.py
@@ -3,6 +3,7 @@
 """Pibooth config menu.
 """
 
+from math import ceil
 import pygame
 import pygame_menu as pgm
 import pibooth
@@ -94,6 +95,9 @@ class PiConfigMenu(object):
                                    self.size[0],
                                    "Settings v{}".format(pibooth.__version__),
                                    theme=THEME_DARK,
+                                   columns=1,
+                                   column_max_width=[self.size[0]],
+                                   rows=20,
                                    onclose=self._on_close)
 
         for name in DEFAULT:
@@ -101,6 +105,15 @@ class PiConfigMenu(object):
             if submenu._widgets:
                 self._main_menu.add_button(submenu.get_title(), submenu)
         self._main_menu.add_button('Exit', pgm.events.EXIT)
+
+        # check if number of submenus + exit is more than 5 to split on 2 columns
+        nb_submenus = len(self._main_menu._submenus)+1
+        if 5 < nb_submenus and self.cfg.getboolean("GENERAL", "split_menu"):
+            self._main_menu._rows = ceil(nb_submenus/2) # round up if odd number
+            self._main_menu._columns = 2
+            self._main_menu._column_max_width = [self.size[0]/2]*2
+            self._main_menu.center_content()
+
         self._main_menu.disable()
 
     def _build_submenu(self, section):

--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -57,6 +57,10 @@ DEFAULT = odict((
                 ('',
                  "Path to custom plugin(s) not installed with pip (list of quoted paths accepted)",
                  None, None)),
+            ("split_menu",
+                (False,
+                 "Split menu on 2 columns instead scrollbar",
+                 "Split menu", ['True', 'False'])),
         ))
      ),
     ("WINDOW",


### PR DESCRIPTION
Original PR is #148

For best visual if try to split menu like this:
Without option ie not split
![Menu5](https://user-images.githubusercontent.com/11534773/82811725-bc9be000-9e91-11ea-8e23-b87e0402d53d.png)
with 1 plugin:
![Menu6](https://user-images.githubusercontent.com/11534773/82811730-bf96d080-9e91-11ea-943a-e8e9fb20caae.png)
with 3 plugins
![scroll](https://user-images.githubusercontent.com/11534773/83035622-fa3b6d00-a039-11ea-9a4d-2da05784a530.png)

With 1 plugin format with my pull request
![Menu6-format](https://user-images.githubusercontent.com/11534773/82811738-c291c100-9e91-11ea-9b2b-29667ba7fd41.png)
With 2 plugins:
![menu7](https://user-images.githubusercontent.com/11534773/82811944-392ebe80-9e92-11ea-94ee-a92b4c23e78d.png)

