### PR TITLE
Reduce the animated pictures size to save memory and avoid deadlock

### DIFF
--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -10,6 +10,7 @@ import tempfile
 import shutil
 import logging
 import argparse
+import multiprocessing
 from warnings import filterwarnings
 
 import pygame
@@ -375,6 +376,10 @@ class PiApplication(object):
 def main():
     """Application entry point.
     """
+    if hasattr(multiprocessing, 'set_start_method'):
+        # Avoid use 'fork': safely forking a multithreaded process is problematic
+        multiprocessing.set_start_method('spawn')
+
     parser = argparse.ArgumentParser(usage="%(prog)s [options]", description=pibooth.__doc__)
 
     parser.add_argument('--version', action='version', version=pibooth.__version__,

--- a/pibooth/pictures/__init__.py
+++ b/pibooth/pictures/__init__.py
@@ -160,7 +160,7 @@ def get_best_orientation(captures):
     return orientation
 
 
-def get_picture_factory(captures, orientation=AUTO, paper_format=(4, 6), force_pil=False):
+def get_picture_factory(captures, orientation=AUTO, paper_format=(4, 6), force_pil=False, dpi=600):
     """Return the picture factory use to concatenate the captures.
 
     :param captures: list of captures to concatenate
@@ -171,6 +171,8 @@ def get_picture_factory(captures, orientation=AUTO, paper_format=(4, 6), force_p
     :type paper_format: tuple
     :param force_pil: force use PIL implementation
     :type force_pil: bool
+    :param dpi: dot-per-inche resolution
+    :type dpi: int
     """
     assert orientation in (AUTO, PORTRAIT, LANDSCAPE), "Unknown orientation '{}'".format(orientation)
     if orientation == AUTO:
@@ -180,8 +182,7 @@ def get_picture_factory(captures, orientation=AUTO, paper_format=(4, 6), force_p
     if paper_format[0] > paper_format[1]:
         paper_format = (paper_format[1], paper_format[0])
 
-    # Consider a resolution of 600 dpi
-    size = (paper_format[0] * 600, paper_format[1] * 600)
+    size = (paper_format[0] * dpi, paper_format[1] * dpi)
     if orientation == LANDSCAPE:
         size = (size[1], size[0])
 

--- a/pibooth/pictures/factory.py
+++ b/pibooth/pictures/factory.py
@@ -273,9 +273,9 @@ class PictureFactory(object):
         assert align in [self.CENTER, self.RIGHT, self.LEFT], "Unknown aligment '{}'".format(align)
         self._texts.append((text, fonts.get_filename(font_name), color, align))
         if self.is_portrait:
-            self._texts_height = int(self.height * 0.167)
+            self._texts_height = int(self.height // 6)
         else:
-            self._texts_height = int(self.height * 0.125)
+            self._texts_height = int(self.height // 8)
         self._final = None  # Force rebuild
 
     def set_background(self, color_or_path):

--- a/pibooth/pictures/factory.py
+++ b/pibooth/pictures/factory.py
@@ -273,9 +273,9 @@ class PictureFactory(object):
         assert align in [self.CENTER, self.RIGHT, self.LEFT], "Unknown aligment '{}'".format(align)
         self._texts.append((text, fonts.get_filename(font_name), color, align))
         if self.is_portrait:
-            self._texts_height = 600
+            self._texts_height = int(self.height * 0.167)
         else:
-            self._texts_height = 300
+            self._texts_height = int(self.height * 0.125)
         self._final = None  # Force rebuild
 
     def set_background(self, color_or_path):
@@ -305,13 +305,19 @@ class PictureFactory(object):
         self._overlay_image = image_path
         self._final = None  # Force rebuild
 
-    def set_margin(self, margin):
+    def set_margin(self, margin, margin_text=None):
         """Set margin between concatenated images.
 
         :param margin: margin in pixels
         :type margin: int
+        :param margin_text: margin between texts in pixels
+        :type margin_text: int
         """
         self._margin = margin
+        if margin_text is None:
+            self._margin_text = margin
+        else:
+            self._margin_text = margin_text
         self._final = None  # Force rebuild
 
     def set_cropping(self, crop=True):

--- a/pibooth/plugins/picture_plugin.py
+++ b/pibooth/plugins/picture_plugin.py
@@ -121,10 +121,11 @@ class PicturePlugin(object):
         if cfg.getboolean('WINDOW', 'animate') and app.capture_nbr > 1:
             with timeit("Asyncronously generate pictures for animation"):
                 for capture in captures:
-                    default_factory = get_picture_factory((capture,), cfg.get('PICTURE', 'orientation'), force_pil=True)
+                    default_factory = get_picture_factory((capture,), cfg.get('PICTURE', 'orientation'), force_pil=True, dpi=200)
                     factory = self._pm.hook.pibooth_setup_picture_factory(cfg=cfg,
                                                                           opt_index=idx,
                                                                           factory=default_factory)
+                    factory.set_margin(factory._margin // 3)  # 1/3 since DPI is divided by 3
                     self.factory_pool.add(factory)
 
     @pibooth.hookimpl


### PR DESCRIPTION
I noticed deadlock / memory error when animated option is True, after several sequences.
This fix reduce the size of pictures processed by the subprocesses pool.

Don't noticed deadlock anymore, but have to perform more tests.