### PR TITLE
#228: Add optional argument to define config directory at startup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -265,7 +265,7 @@ Configuration
 -------------
 
 At the first run, a configuration file is generated in ``~/.config/pibooth/pibooth.cfg``
-which permits to configure the behavior of the application.
+by default. This file permits to configure the behavior of the application.
 
 A quick configuration GUI menu (see `Commands`_ ) gives access to the most common options:
 
@@ -282,6 +282,13 @@ The default configuration can be restored with the command (strongly recommended
 upgrading ``pibooth``)::
 
     $ pibooth --reset
+
+The configuration directory can be chosen at startup. This feature gives the possibility
+to keep several configurations on the same Raspberry Pi and quickly switch from one
+configuration to another. The following command will start ``pibooth`` using configuration
+files from ``myconfig1/`` directory::
+
+    $ pibooth myconfig1/
 
 See the `default configuration file <https://github.com/pibooth/pibooth/blob/master/docs/config.rst>`_
 for further details.

--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -423,7 +423,7 @@ def main():
 
     parser = argparse.ArgumentParser(usage="%(prog)s [options]", description=pibooth.__doc__)
 
-    parser.add_argument("directory", nargs='?', default="~/.config/pibooth",
+    parser.add_argument("config_directory", nargs='?', default="~/.config/pibooth",
                         help=u"path to configuration directory (default: %(default)s)")
 
     parser.add_argument('--version', action='version', version=pibooth.__version__,
@@ -461,7 +461,7 @@ def main():
     plugin_manager = create_plugin_manager()
 
     # Load the configuration
-    config = PiConfigParser(osp.join(options.directory, "pibooth.cfg"), plugin_manager, not options.reset)
+    config = PiConfigParser(osp.join(options.config_directory, "pibooth.cfg"), plugin_manager, not options.reset)
 
     # Register plugins
     custom_paths = [p for p in config.gettuple('GENERAL', 'plugins', 'path') if p]

--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -263,7 +263,7 @@ class PiApplication(object):
                 # 4 fingers on the screen trigger the menu
                 self._fingerdown_events = []
                 return pygame.event.Event(BUTTONDOWN, capture=1, printer=1,
-                                               button=self.buttons)
+                                          button=self.buttons)
         return None
 
     def find_fullscreen_event(self, events):
@@ -308,7 +308,7 @@ class PiApplication(object):
         """
         for event in events:
             if event.type == pygame.KEYDOWN and event.key == pygame.K_e\
-                        and pygame.key.get_mods() & pygame.KMOD_CTRL:
+                    and pygame.key.get_mods() & pygame.KMOD_CTRL:
                 return event
             if event.type == pygame.MOUSEBUTTONUP and event.button in (1, 2, 3):
                 # Don't consider the mouse wheel (button 4 & 5):
@@ -423,6 +423,9 @@ def main():
 
     parser = argparse.ArgumentParser(usage="%(prog)s [options]", description=pibooth.__doc__)
 
+    parser.add_argument("directory", nargs='?', default="~/.config/pibooth",
+                        help=u"path to configuration directory (default: %(default)s)")
+
     parser.add_argument('--version', action='version', version=pibooth.__version__,
                         help=u"show program's version number and exit")
 
@@ -447,7 +450,7 @@ def main():
     group.add_argument("-q", "--quiet", dest='logging', action='store_const', const=logging.WARNING,
                        help=u"report only errors and warnings", default=logging.INFO)
 
-    options, _args = parser.parse_known_args()
+    options = parser.parse_args()
 
     if not options.nolog:
         filename = osp.join(tempfile.gettempdir(), 'pibooth.log')
@@ -458,7 +461,7 @@ def main():
     plugin_manager = create_plugin_manager()
 
     # Load the configuration
-    config = PiConfigParser("~/.config/pibooth/pibooth.cfg", plugin_manager, not options.reset)
+    config = PiConfigParser(osp.join(options.directory, "pibooth.cfg"), plugin_manager, not options.reset)
 
     # Register plugins
     custom_paths = [p for p in config.gettuple('GENERAL', 'plugins', 'path') if p]


### PR DESCRIPTION
Configuration directory can be chosen at startup.
It allows to have different ``pibooth`` configuration saved on the same raspberry-pi.

```bash
$ pibooth my_config
```