### PR TITLE
Force pygame 2+ update to fix touchscreen crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def main():
             'picamera>=1.13 ; platform_machine>="armv0l" and platform_machine<="armv9l"',
             # Pillow freeze: higher versions bugged (see PR #5434)
             'Pillow==7.1.2',
-            'pygame>=1.9.6',
+            'pygame>=2.0.1',
             'pygame-menu==4.0.4',
             'pygame-vkeyboard>=2.0.8',
             'psutil>=5.5.1',

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ def main():
             'picamera>=1.13 ; platform_machine>="armv0l" and platform_machine<="armv9l"',
             # Pillow freeze: higher versions bugged (see PR #5434)
             'Pillow==7.1.2',
-            'pygame>=2.0.1',
-            'pygame-menu==4.0.4',
+            'pygame>=1.9.6',
+            'pygame-menu==4.0.5',
             'pygame-vkeyboard>=2.0.8',
             'psutil>=5.5.1',
             'pluggy>=0.13.1',


### PR DESCRIPTION
By updating **pibooth v2.0.2** from an **old version** with **pygame v1.9.6**, the app **crash** when opening the menu `touchscreen is only supported in pygame v2+`.

After forcing the update of **pygame v2.0.1* (latest version), the app runs like a charm :smiley: 