### PR TITLE
Drop Python2.7 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -408,9 +408,9 @@ If you want to help us you can by clicking on the following links!
 .. |Pibooth| image:: https://raw.githubusercontent.com/pibooth/pibooth/master/templates/pibooth.png
    :align: middle
 
-.. |PythonVersions| image:: https://img.shields.io/badge/python-2.7+ / 3.6+-red.svg
+.. |PythonVersions| image:: https://img.shields.io/badge/python-3.6+-red.svg
    :target: https://www.python.org/downloads
-   :alt: Python 2.7+/3.6+
+   :alt: Python 3.6+
 
 .. |PypiPackage| image:: https://badge.fury.io/py/pibooth.svg
    :target: https://pypi.org/project/pibooth

--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -9,22 +9,10 @@ import os
 import os.path as osp
 import itertools
 import inspect
+from configparser import RawConfigParser
 from collections import OrderedDict as odict
 from pibooth.utils import LOGGER, open_text_editor
 from pibooth import language
-
-
-try:
-    from configparser import RawConfigParser
-except ImportError:
-    # Python 2.x fallback
-    from ConfigParser import RawConfigParser
-
-try:
-    basestring
-except NameError:
-    # Python 3.x fallback
-    basestring = str
 
 
 def values_list_repr(values):
@@ -434,9 +422,6 @@ class PiConfigParser(RawConfigParser):
         else:
             types = list(types)
 
-        if str in types:  # Python 2.x compat
-            types[types.index(str)] = basestring
-
         color = False
         if 'color' in types:
             types.remove('color')
@@ -447,7 +432,7 @@ class PiConfigParser(RawConfigParser):
         path = False
         if 'path' in types:
             types.remove('path')
-            types.append(basestring)
+            types.append(str)
             path = True  # Option accept file path
 
         types = tuple(types)
@@ -492,7 +477,7 @@ class PiConfigParser(RawConfigParser):
         if path:
             new_values = []
             for v in values:
-                if isinstance(v, basestring):
+                if isinstance(v, str):
                     new_values.append(self._get_abs_path(v))
                 else:
                     new_values.append(v)

--- a/pibooth/language.py
+++ b/pibooth/language.py
@@ -6,13 +6,9 @@
 import io
 import os
 import os.path as osp
+from configparser import ConfigParser
 from pibooth.utils import LOGGER, open_text_editor
 
-try:
-    from configparser import ConfigParser
-except ImportError:
-    # Python 2.x fallback
-    from ConfigParser import ConfigParser
 
 PARSER = ConfigParser()
 

--- a/pibooth/utils.py
+++ b/pibooth/utils.py
@@ -15,12 +15,8 @@ from fnmatch import fnmatchcase
 import contextlib
 import errno
 import subprocess
+from itertools import zip_longest, islice
 import pygame
-try:
-    from itertools import zip_longest, islice
-except ImportError:
-    # Python 2.x fallback
-    from itertools import izip_longest as zip_longest, islice
 
 
 LOGGER = logging.getLogger("pibooth")

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ def main():
             'Intended Audience :: End Users/Desktop',
             'License :: OSI Approved :: MIT License',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
             'Natural Language :: Danish',
             'Natural Language :: Dutch',
             'Natural Language :: English',
@@ -74,10 +74,6 @@ def main():
         extras_require={
             'dslr': ['gphoto2>=2.0.0'],
             'printer': ['pycups>=1.9.73', 'pycups-notify>=0.0.4'],
-        },
-        options={
-            'bdist_wheel':
-                {'universal': True}
         },
         zip_safe=False,  # Don't install the lib as an .egg zipfile
         entry_points={'console_scripts': ["pibooth = pibooth.booth:main",


### PR DESCRIPTION
### It's time to leave...
I've seen that last `pygame-menu` 4.x versions are, in fact, no more compatible with Python 2.7.
Moreover it will more and more difficult to keep compatibility with all dependencies.