### PR TITLE
Fix #272: Rotation option can be a list of 2 integers for preview and capture

### DIFF
--- a/docs/sources/config/default.cfg
+++ b/docs/sources/config/default.cfg
@@ -98,13 +98,13 @@ overlays =
 backgrounds = (255, 255, 255)
 
 [CAMERA]
-# Adjust ISO for lighting issues, can be different for preview and capture (list of integer accepted)
+# Adjust ISO for lighting issues, can be different for preview and capture (list of integers accepted)
 iso = 100
 
 # Flip horizontally the capture
 flip = False
 
-# Rotation of the camera: 0, 90, 180 or 270
+# Rotation of the camera: 0, 90, 180 or 270, can be different for preview and capture (list of integers accepted)
 rotation = 0
 
 # Resolution for camera captures (preview will have same aspect ratio)

--- a/pibooth/camera/base.py
+++ b/pibooth/camera/base.py
@@ -16,18 +16,23 @@ class BaseCamera(object):
         self._overlay = None
         self._captures = []
 
-        self.rotation = 0
         self.resolution = None
         self.delete_internal_memory = False
+        self.preview_rotation, self.capture_rotation = (0, 0)
         self.preview_iso, self.capture_iso = (100, 100)
         self.preview_flip, self.capture_flip = (False, False)
 
     def initialize(self, iso, resolution, rotation=0, flip=False, delete_internal_memory=False):
         """Initialize the camera.
         """
-        if rotation not in (0, 90, 180, 270):
-            raise ValueError("Invalid camera rotation value '{}' (should be 0, 90, 180 or 270)".format(rotation))
-        self.rotation = rotation
+        if not isinstance(rotation, (tuple, list)):
+            rotation = (rotation, rotation)
+        self.preview_rotation, self.capture_rotation = rotation
+        for name in ('preview', 'capture'):
+            rotation = getattr(self, '{}_rotation'.format(name))
+            if rotation not in (0, 90, 180, 270):
+                raise ValueError(
+                    "Invalid {} camera rotation value '{}' (should be 0, 90, 180 or 270)".format(name, rotation))
         self.resolution = resolution
         self.capture_flip = flip
         if not isinstance(iso, (tuple, list)):

--- a/pibooth/camera/gphoto.py
+++ b/pibooth/camera/gphoto.py
@@ -110,14 +110,14 @@ class GpCamera(BaseCamera):
             rect = self.get_rect()
             self._overlay = self.build_overlay((rect.width, rect.height), str(text), alpha)
 
-    def _rotate_image(self, image):
+    def _rotate_image(self, image, rotation):
         """Rotate a PIL image, same direction than RpiCamera.
         """
-        if self.rotation == 90:
+        if rotation == 90:
             return image.transpose(Image.ROTATE_90)
-        elif self.rotation == 180:
+        elif rotation == 180:
             return image.transpose(Image.ROTATE_180)
-        elif self.rotation == 270:
+        elif rotation == 270:
             return image.transpose(Image.ROTATE_270)
         return image
 
@@ -128,7 +128,7 @@ class GpCamera(BaseCamera):
         if self._preview_compatible:
             cam_file = self._cam.capture_preview()
             image = Image.open(io.BytesIO(cam_file.get_data_and_size()))
-            image = self._rotate_image(image)
+            image = self._rotate_image(image, self.preview_rotation)
             # Crop to keep aspect ratio of the resolution
             image = image.crop(sizing.new_size_by_croping_ratio(image.size, self.resolution))
             # Resize to fit the available space in the window
@@ -155,7 +155,7 @@ class GpCamera(BaseCamera):
             LOGGER.debug("Delete capture '%s' from internal memory", gp_path.name)
             self._cam.file_delete(gp_path.folder, gp_path.name)
         image = Image.open(io.BytesIO(camera_file.get_data_and_size()))
-        image = self._rotate_image(image)
+        image = self._rotate_image(image, self.capture_rotation)
 
         # Crop to keep aspect ratio of the resolution
         image = image.crop(sizing.new_size_by_croping_ratio(image.size, self.resolution))

--- a/pibooth/camera/opencv.py
+++ b/pibooth/camera/opencv.py
@@ -78,15 +78,15 @@ class CvCamera(BaseCamera):
             # Remove alpha from overlay
             self._overlay = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGBA2RGB)
 
-    def _rotate_image(self, image):
+    def _rotate_image(self, image, rotation):
         """Rotate an OpenCV image, same direction than RpiCamera.
         """
-        if self.rotation == 90:
+        if rotation == 90:
             image = cv2.transpose(image)
             return cv2.flip(image, 1)
-        elif self.rotation == 180:
+        elif rotation == 180:
             return cv2.flip(image, -1)
-        elif self.rotation == 270:
+        elif rotation == 270:
             image = cv2.transpose(image)
             return cv2.flip(image, 0)
         return image
@@ -99,7 +99,7 @@ class CvCamera(BaseCamera):
         ret, image = self._cam.read()
         if not ret:
             raise IOError("Can not get camera preview image")
-        image = self._rotate_image(image)
+        image = self._rotate_image(image, self.preview_rotation)
 
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         # Crop to keep aspect ratio of the resolution
@@ -218,7 +218,7 @@ class CvCamera(BaseCamera):
         ret, image = self._cam.read()
         if not ret:
             raise IOError("Can not capture frame")
-        image = self._rotate_image(image)
+        image = self._rotate_image(image, self.capture_rotation)
 
         LOGGER.debug("Putting preview resolution back to %s", self._preview_resolution)
         self._cam.set(cv2.CAP_PROP_FRAME_WIDTH, self._preview_resolution[0])

--- a/pibooth/camera/rpi.py
+++ b/pibooth/camera/rpi.py
@@ -53,7 +53,7 @@ class RpiCamera(BaseCamera):
         self._cam.hflip = self.capture_flip
         self._cam.resolution = self.resolution
         self._cam.iso = self.preview_iso
-        self._cam.rotation = self.rotation
+        self._cam.rotation = self.preview_rotation
 
     def _show_overlay(self, text, alpha):
         """Add an image as an overlay.
@@ -145,6 +145,8 @@ class RpiCamera(BaseCamera):
         try:
             if self.capture_iso != self.preview_iso:
                 self._cam.iso = self.capture_iso
+            if self.capture_rotation != self.preview_rotation:
+                self._cam.rotation = self.capture_rotation
 
             stream = BytesIO()
             self._cam.image_effect = effect
@@ -152,6 +154,8 @@ class RpiCamera(BaseCamera):
 
             if self.capture_iso != self.preview_iso:
                 self._cam.iso = self.preview_iso
+            if self.capture_rotation != self.preview_rotation:
+                self._cam.rotation = self.preview_rotation
 
             self._captures.append(stream)
         finally:

--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -166,7 +166,7 @@ DEFAULT = odict((
         odict((
             ("iso",
                 (100,
-                 "Adjust ISO for lighting issues, can be different for preview and capture (list of integer accepted)",
+                 "Adjust ISO for lighting issues, can be different for preview and capture (list of integers accepted)",
                  None, None)),
             ("flip",
                 (False,
@@ -174,7 +174,7 @@ DEFAULT = odict((
                  None, None)),
             ("rotation",
                 (0,
-                 "Rotation of the camera: 0, 90, 180 or 270",
+                 "Rotation of the camera: 0, 90, 180 or 270, can be different for preview and capture (list of integers accepted)",
                  None, None)),
             ("resolution",
                 ((1934, 2464),

--- a/pibooth/plugins/camera_plugin.py
+++ b/pibooth/plugins/camera_plugin.py
@@ -27,7 +27,7 @@ class CameraPlugin(object):
 
         cam.initialize(cfg.gettuple('CAMERA', 'iso', int, 2),
                        cfg.gettyped('CAMERA', 'resolution'),
-                       cfg.getint('CAMERA', 'rotation'),
+                       cfg.gettuple('CAMERA', 'rotation', int, 2),
                        cfg.getboolean('CAMERA', 'flip'),
                        cfg.getboolean('CAMERA', 'delete_internal_memory'))
         outcome.force_result(cam)


### PR DESCRIPTION
@sravel can you check this development with and without your DSLR connected?
The option `rotation` can now accept a list of 2 integers: first for preview rotation, second for capture rotation.