### PR TITLE
Fix #280: Limit the max preview resolution of Raspberry-Pi camera

### DIFF
--- a/pibooth/camera/base.py
+++ b/pibooth/camera/base.py
@@ -62,13 +62,15 @@ class BaseCamera(object):
         """
         raise NotImplementedError
 
-    def get_rect(self):
+    def get_rect(self, max_size=None):
         """Return a Rect object (as defined in pygame) for resizing preview and images
         in order to fit to the defined window.
         """
         rect = self._window.get_rect(absolute=True)
-        res = sizing.new_size_keep_aspect_ratio(self.resolution,
-                                                (rect.width - 2 * self._border, rect.height - 2 * self._border))
+        size = (rect.width - 2 * self._border, rect.height - 2 * self._border)
+        if max_size:
+            size = (min(size[0], max_size[0]), min(size[1], max_size[1]))
+        res = sizing.new_size_keep_aspect_ratio(self.resolution, size)
         return pygame.Rect(rect.centerx - res[0] // 2, rect.centery - res[1] // 2, res[0], res[1])
 
     def build_overlay(self, size, text, alpha):

--- a/pibooth/camera/rpi.py
+++ b/pibooth/camera/rpi.py
@@ -101,6 +101,7 @@ class RpiCamera(BaseCamera):
             else:
                 # Flip again because flipped once at init
                 flip = True
+        print("preview params ->", (rect.width, rect.height), flip, tuple(rect))
         self._cam.start_preview(resolution=(rect.width, rect.height), hflip=flip,
                                 fullscreen=False, window=tuple(rect))
 

--- a/pibooth/camera/rpi.py
+++ b/pibooth/camera/rpi.py
@@ -59,7 +59,7 @@ class RpiCamera(BaseCamera):
         """Add an image as an overlay.
         """
         if self._window:  # No window means no preview displayed
-            rect = self.get_rect()
+            rect = self.get_rect(self._cam.MAX_RESOLUTION)
 
             # Create an image padded to the required size (required by picamera)
             size = (((rect.width + 31) // 32) * 32, ((rect.height + 15) // 16) * 16)
@@ -93,10 +93,10 @@ class RpiCamera(BaseCamera):
             return
 
         self._window = window
-        rect = self.get_rect()
+        rect = self.get_rect(self._cam.MAX_RESOLUTION)
         if self._cam.hflip:
             if flip:
-                 # Don't flip again, already done at init
+                # Don't flip again, already done at init
                 flip = False
             else:
                 # Flip again because flipped once at init

--- a/pibooth/camera/rpi.py
+++ b/pibooth/camera/rpi.py
@@ -101,7 +101,6 @@ class RpiCamera(BaseCamera):
             else:
                 # Flip again because flipped once at init
                 flip = True
-        print("preview params ->", (rect.width, rect.height), flip, tuple(rect))
         self._cam.start_preview(resolution=(rect.width, rect.height), hflip=flip,
                                 fullscreen=False, window=tuple(rect))
 


### PR DESCRIPTION
In case of 4K screen used, avoid setting the preview resolution upper than the maximal camera resolution