### PR TITLE
Update installation instructions

### DIFF
--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -27,7 +27,7 @@ Hardware
 Software
 ^^^^^^^^
 
-* Raspberry Pi OS with desktop
+* Raspberry Pi OS Buster with desktop
 * Python ``3.7.3``
 * libsdl2 ``2.0``
 * libgphoto2 ``2.5.27``
@@ -70,8 +70,9 @@ installed. Instead of doing step 8. of the below procedure, follow
 
    .. code-block:: bash
 
-        sudo wget raw.github.com/gonzalo/gphoto2-updater/master/gphoto2-updater.sh
-        sudo chmod 755 gphoto2-updater.sh
+        wget https://raw.githubusercontent.com/gonzalo/gphoto2-updater/master/gphoto2-updater.sh
+        wget https://raw.githubusercontent.com/gonzalo/gphoto2-updater/master/.env
+        chmod +x gphoto2-updater.sh
         sudo ./gphoto2-updater.sh
 
 6. Optionally install ``CUPS`` to handle printers (more instructions to add a


### PR DESCRIPTION
Fixed minor errors in the installation instructions:
- as of now, Pibooth is does not work with the latest Raspberry Pi OS release (Bullseye), but on the older on (Buster) and this is not stated anywhere
- the gPhoto2 installation instructions where missing the download of the .env file, which is needed for the gphoto2-updater.sh script to work properly