### PR TITLE
Fix #373: Accept string as ISO values

### DIFF
--- a/pibooth/plugins/camera_plugin.py
+++ b/pibooth/plugins/camera_plugin.py
@@ -27,7 +27,7 @@ class CameraPlugin(object):
             LOGGER.debug("Fallback to pibooth default camera management system")
             cam = camera.find_camera()
 
-        cam.initialize(cfg.gettuple('CAMERA', 'iso', int, 2),
+        cam.initialize(cfg.gettuple('CAMERA', 'iso', (int, str), 2),
                        cfg.gettyped('CAMERA', 'resolution'),
                        cfg.gettuple('CAMERA', 'rotation', int, 2),
                        cfg.getboolean('CAMERA', 'flip'),


### PR DESCRIPTION
Accepts strings as values for ISO. 

The change was needed since the value for auto ISO is "ISO Auto" for my camera.
Implemented and tested with my setup (RPI4, Sony a6300).