### PR TITLE
Do not attempt to resize or update scene if it's not set yet

### DIFF
--- a/pibooth/view/pygame/window.py
+++ b/pibooth/view/pygame/window.py
@@ -123,7 +123,8 @@ class PygameWindow(BaseWindow):
         self.background_sprite.set_rect(*self.get_rect())
         width, height = self.get_rect().width // 20, self.get_rect().height * 2 // 5
         self.statusbar_sprite.set_rect(0, self.get_rect().height - height, width, height)
-        self.scene.resize(self.get_rect().size)
+        if self.scene:
+            self.scene.resize(self.get_rect().size)
 
     def get_rect(self, absolute=False):
         """Return a Rect object (as defined in pygame) for this window.
@@ -155,7 +156,8 @@ class PygameWindow(BaseWindow):
 
         size = self.get_rect().size
         self.resize(size)
-        self.scene.update([])  # Do not acts on scenes, but recreate sprites with correct size
+        if self.scene:
+            self.scene.update([])  # Do not acts on scenes, but recreate sprites with correct size
         if self._menu:
             self._menu.resize((min(size[0]*0.75, 600), size[1]*0.75))
 


### PR DESCRIPTION
pibooth 3.x would crash if started in full screen:
```
Traceback (most recent call last):
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/app.py", line 269, in exec
    self._initialize()
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/app.py", line 157, in _initialize
    self._window.toggle_fullscreen()
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/view/pygame/window.py", line 157, in toggle_fullscreen
    self.resize(size)
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/view/pygame/window.py", line 126, in resize
    self.scene.resize(self.get_rect().size)
AttributeError: 'NoneType' object has no attribute 'resize'
```

And again once fixed there:
```
Traceback (most recent call last):
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/app.py", line 269, in exec
    self._initialize()
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/app.py", line 157, in _initialize
    self._window.toggle_fullscreen()
  File "/home/gilou/.virtualenvs/piboothv3/lib/python3.10/site-packages/pibooth/view/pygame/window.py", line 159, in toggle_fullscreen
    self.scene.update([])  # Do not acts on scenes, but recreate sprites with correct size
AttributeError: 'NoneType' object has no attribute 'update'

```

So I just added a condition so that the resize and update would still happen if self.scene was setup!
