### PR TITLE
Fix right text align outside of the text box.

### DIFF
--- a/pibooth/view/background.py
+++ b/pibooth/view/background.py
@@ -40,7 +40,7 @@ def multiline_text_to_surfaces(text, color, rect, align='center'):
         elif align.endswith('center'):
             x = rect.centerx - surface.get_rect().width / 2
         elif align.endswith('right'):
-            x = rect.right - surface.get_rect().width / 2
+            x = rect.right - surface.get_rect().width
         else:
             raise ValueError("Invalid horizontal alignment '{}'".format(align))
 


### PR DESCRIPTION
The alignment option seems to calculate the `x` value wrong for `right` text alignment. The text appears outside of the box. Maybe I am overlooking something but without `/ 2` it works smoothly for me.

![image](https://github.com/pibooth/pibooth/assets/2273779/99ea351a-d462-4e38-8542-5c7469cb139f)
