### PR TITLE
Implement two keyboard buttons for usage in addition to hardware buttons.

### DIFF
--- a/pibooth/booth.py
+++ b/pibooth/booth.py
@@ -307,6 +307,8 @@ class PiApplication(object):
         for event in events:
             if event.type == pygame.KEYDOWN and event.key == pygame.K_p:
                 return event
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_LEFT:
+                return event
             if (event.type == pygame.MOUSEBUTTONUP and event.button in (1, 2, 3)) or event.type == pygame.FINGERUP:
                 pos = get_event_pos(self._window.display_size, event)
                 rect = self._window.get_rect()
@@ -322,6 +324,8 @@ class PiApplication(object):
         for event in events:
             if event.type == pygame.KEYDOWN and event.key == pygame.K_e\
                     and pygame.key.get_mods() & pygame.KMOD_CTRL:
+                return event
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_RIGHT:
                 return event
             if (event.type == pygame.MOUSEBUTTONUP and event.button in (1, 2, 3)) or event.type == pygame.FINGERUP:
                 pos = get_event_pos(self._window.display_size, event)


### PR DESCRIPTION
I built wireless hardware buttons based on an ESP32 emulating a BLE keyboard and connecting to a Raspberry Pi running Pibooth. Pibooth does already support the control with a keyboard (for debugging?) but the keys change from view to view. On the intro view one can only continue with the keys `P` or `Ctrl + E`, on the choice view one need to press arrow keys `left` or `right`.

With the changes I implemented, the control of all views (except the settings) is now possible with only the two arrow keys `left` and `right` in addition to the two hardware buttons directly connected to the Pi. Thus, my two BLE wireless buttons can now just send the two respective keys to control Pibooth wirelessly from the photo area.

I didn't see any conflicts occurring with the implementation as it doesn't remove but only adds functionality.