### PR TITLE
Update install.rst with hint that 32 bit version is required

### DIFF
--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -27,7 +27,7 @@ Hardware
 Software
 ^^^^^^^^
 
-* Raspberry Pi OS **Buster** with desktop
+* `Raspberry Pi OS **Buster** (32 bit) with desktop <https://downloads.raspberrypi.org/raspios_oldstable_armhf/images/>`_
 * Python ``3.7.3``
 * libsdl2 ``2.0``
 * libgphoto2 ``2.5.27``


### PR DESCRIPTION
added a hint that a 32bit version of Buster is required and a link to the oldstable armhf images