### PR TITLE
Add optional config directory argument to pibooth-regen script

### DIFF
--- a/docs/sources/scripts.rst
+++ b/docs/sources/scripts.rst
@@ -32,6 +32,12 @@ To regenerate the final pictures afterwards, from the originals captures present
 It permits to adjust the configuration to enhance the previous pictures with better
 parameters (title, more effects, etc...)
 
+Like with the ``pibooth`` application a configuration directory can be chosen.
+
+.. code-block:: bash
+
+    pibooth-regen myconfig1/
+
 Manage counters
 ---------------
 

--- a/pibooth/scripts/regenerate.py
+++ b/pibooth/scripts/regenerate.py
@@ -6,6 +6,7 @@
 import os
 from os import path as osp
 from datetime import datetime
+import argparse
 
 from PIL import Image
 
@@ -65,9 +66,16 @@ def regenerate_all_images(plugin_manager, config, basepath):
 def main():
     """Application entry point.
     """
+    parser = argparse.ArgumentParser(usage="%(prog)s [options]", description="This script lets you regenerate the final pictures from the original captures present in the raw directory.")
+
+    parser.add_argument("config_directory", nargs='?', default="~/.config/pibooth",
+                        help=u"path to configuration directory (default: %(default)s)")
+
+    options = parser.parse_args()
+
     configure_logging()
     plugin_manager = create_plugin_manager()
-    config = PiConfigParser("~/.config/pibooth/pibooth.cfg", plugin_manager)
+    config = PiConfigParser(osp.join(options.config_directory, "pibooth.cfg"), plugin_manager)
 
     # Register plugins
     plugin_manager.load_all_plugins(config.gettuple('GENERAL', 'plugins', 'path'),


### PR DESCRIPTION
When doing a `pibooth-regen` one is limited to use the default `~/.config/pibooth` directory to grab the `pibooth.cfg`. With this change it is possible to have a different location. It follows the same argument concept like the main `pibooth` application.