### PR TITLE
Document the architecture and the developer workflow

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,10 @@ photos of your version.
    :hidden:
 
    sources/dev/install.rst
+   sources/dev/architecture.rst
    sources/dev/rules.rst
+   sources/dev/tests.rst
+   sources/dev/translations.rst
    sources/dev/release.rst
 
 Indices and tables
@@ -77,9 +80,9 @@ Indices and tables
    :target: https://www.pibooth.org
    :align: middle
 
-.. |PythonVersions| image:: https://img.shields.io/badge/python-3.6+-red.svg
+.. |PythonVersions| image:: https://img.shields.io/badge/python-3.10+-red.svg
    :target: https://www.python.org/downloads
-   :alt: Python 3.6+
+   :alt: Python 3.10+
 
 .. |PypiPackage| image:: https://badge.fury.io/py/pibooth.svg
    :target: https://pypi.org/project/pibooth

--- a/docs/sources/dev/architecture.rst
+++ b/docs/sources/dev/architecture.rst
@@ -66,9 +66,10 @@ Plugins call order
 
 Hooks are called in **LIFO order**: the last plugin registered is called first.
 The core plugins are therefore registered last **on purpose**, so that they run
-before any external plugin, and in the order given by the list in
-``pibooth/plugins/__init__.py`` — ``CameraPlugin`` first, ``LightsPlugin`` last.
-Reordering that list changes the runtime behaviour.
+before any external plugin. The list in ``pibooth/plugins/__init__.py`` is written
+in *registration* order (``LightsPlugin`` first, ``CameraPlugin`` last), which is
+the reverse of the *call* order — ``CameraPlugin`` is called first and
+``LightsPlugin`` last. Reordering that list changes the runtime behaviour.
 
 .. warning:: This has a consequence that surprises plugin authors. The
              ``state_<name>_validate`` hooks are declared ``firstresult=True``,
@@ -150,6 +151,3 @@ Most of the hardware-facing code cannot be exercised on a development machine:
 ``camera/__init__.py::find_camera()`` probes the available backends; on a
 development machine it usually resolves to ``CvCamera`` when a webcam is
 present, and raises otherwise.
-
-Say plainly when a change could not be verified on real hardware, rather than
-implying it was tested.

--- a/docs/sources/dev/architecture.rst
+++ b/docs/sources/dev/architecture.rst
@@ -1,0 +1,155 @@
+Architecture
+------------
+
+``pibooth`` is a `pygame <https://www.pygame.org>`_ application driven by a state
+machine, in which **every behaviour is implemented as a plugin** — including the
+core features themselves.
+
+Modules
+^^^^^^^
+
+::
+
+    booth.py            PiApplication + main_loop(): pygame event loop, GPIO buttons/LEDs
+     ├─ states.py       StateMachine: calls the state_<name>_* hooks
+     ├─ plugins/        plugin manager and the 5 core plugins
+     │   ├─ hookspecs.py       every hook available to plugins
+     │   ├─ camera_plugin.py   captures sequence
+     │   ├─ picture_plugin.py  final picture assembly
+     │   ├─ printer_plugin.py  CUPS printing
+     │   ├─ view_plugin.py     screens and transitions
+     │   └─ lights_plugin.py   GPIO LEDs
+     ├─ config/         parser.py (DEFAULT) + menu.py (graphical settings)
+     ├─ camera/         base.py + rpi/gphoto/opencv/hybrid backends, auto-detected
+     ├─ pictures/       factory.py (build the final picture), sizing.py, pool.py
+     ├─ view/           window.py (PiWindow) + background.py (one class per screen)
+     ├─ language.py     translations, one section per language
+     ├─ counters.py     persisted counters
+     └─ utils.py        LOGGER, PoolingTimer, logging helpers
+
+The application entry point is ``pibooth.booth:main``. The other ``pibooth-*``
+commands live in ``pibooth/scripts/``.
+
+State machine
+^^^^^^^^^^^^^
+
+The list of states and the four hooks defined for each of them are described in
+:ref:`extend_pibooth_functionalities`. What matters here is how
+``StateMachine`` (``pibooth/states.py``) uses them.
+
+On each iteration of the main loop, for the active state, it calls:
+
+1. ``state_<name>_do(cfg, app, win, events)``
+2. ``state_<name>_validate(cfg, app, win, events)``, which returns the name of
+   the next state or ``None``
+
+and, when a transition happens, ``state_<name>_exit`` then the
+``state_<name>_enter`` of the new state.
+
+.. important:: A transition only ever happens because a ``_validate`` hook
+               returned a state name. There is no other way to change state,
+               and no state should be activated from anywhere else.
+
+If an exception escapes a hook, the machine switches to the ``failsafe`` state
+instead of propagating — unless the ``[GENERAL][debug]`` option is enabled, in
+which case ``failsafe`` is removed and exceptions are raised. Keep that in mind
+when a plugin seems to swallow errors.
+
+Plugins call order
+^^^^^^^^^^^^^^^^^^
+
+``PiPluginManager.load_all_plugins()`` registers, in this order:
+
+1. plugins declared through ``setuptools`` entry points (installed with ``pip``)
+2. the plugins listed in ``[GENERAL][plugins]``
+3. the five core plugins
+
+Hooks are called in **LIFO order**: the last plugin registered is called first.
+The core plugins are therefore registered last **on purpose**, so that they run
+before any external plugin, and in the order given by the list in
+``pibooth/plugins/__init__.py`` — ``CameraPlugin`` first, ``LightsPlugin`` last.
+Reordering that list changes the runtime behaviour.
+
+.. warning:: This has a consequence that surprises plugin authors. The
+             ``state_<name>_validate`` hooks are declared ``firstresult=True``,
+             so the **first** non-``None`` result wins and the remaining
+             implementations are not even called. Since core plugins run first,
+             an external plugin cannot prevent a transition that a core plugin
+             has already decided.
+
+             Returning ``None`` from ``state_finish_validate`` for instance does
+             not keep the application on the finish screen: ``ViewPlugin`` has
+             already returned ``'wait'`` once its timer expired.
+
+Right after loading, ``check_pending()`` runs: any hook implementation whose
+name is not declared in ``hookspecs.py`` raises at startup, unless it is
+decorated with ``@pibooth.hookimpl(optionalhook=True)``.
+
+Hooks are a public API
+^^^^^^^^^^^^^^^^^^^^^^
+
+``pibooth/plugins/hookspecs.py`` is consumed by third-party plugins published on
+PyPI, and its docstrings are rendered as :ref:`hooks`.
+
+* adding a hook, or adding a parameter to an existing one, is backward
+  compatible — implementations only declare the arguments they use
+* renaming a hook, removing one, or removing a parameter breaks every installed
+  plugin that uses it
+
+Configuration
+^^^^^^^^^^^^^
+
+``pibooth/config/parser.py::DEFAULT`` is the single source of truth. Each option
+is a 4-tuple::
+
+    ("option_name", (default_value,
+                     "comment written in pibooth.cfg",
+                     "label in the graphical menu" or None,
+                     choices or None))
+
+The 3rd and 4th items are ``None`` together for an option that exists only in
+the file and is not exposed in the settings menu. Choices are strings, even for
+numeric options.
+
+The user file is **merged** with ``DEFAULT``, never overwritten: an option
+missing from the user file falls back to its default. As a consequence, removing
+or renaming an option silently changes the behaviour of existing installations.
+
+Read options with the matching typed getter — ``gettyped``, ``gettuple``,
+``getpath``, ``getint``, ``getfloat``, ``getboolean`` — rather than ``get`` and a
+manual conversion.
+
+An option that must apply without restarting has to be read in
+``PiApplication._initialize()``, which runs at startup *and* every time the
+settings menu is closed. Options read only in ``__init__`` require a restart.
+
+Plugins declare their own options from the ``pibooth_configure`` hook with
+``cfg.add_option(...)``, whose signature mirrors the tuple above.
+
+.. note:: When ``DEFAULT`` changes, update ``docs/sources/config/default.cfg``
+          as well: it is maintained by hand. It should stay identical to a
+          freshly generated file, apart from its missing trailing newline::
+
+              pibooth --reset /tmp/piboothcfg
+              diff /tmp/piboothcfg/pibooth.cfg docs/sources/config/default.cfg
+
+What cannot run outside a Raspberry Pi
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Most of the hardware-facing code cannot be exercised on a development machine:
+
+* **GPIO** — ``booth.py`` catches ``BadPinFactory`` and falls back to
+  ``gpiozero``'s mock factory, logging *without physical GPIO*. Button and LED
+  code runs but has no effect.
+* **Pi Camera** — ``picamera`` is only installed on 32-bit ARM, so ``RpiCamera``
+  and both hybrid cameras are unreachable elsewhere.
+* **DSLR and printing** — need real hardware, plus ``gphoto2`` and a CUPS
+  server. Both are optional extras, and the corresponding modules guard their
+  imports.
+
+``camera/__init__.py::find_camera()`` probes the available backends; on a
+development machine it usually resolves to ``CvCamera`` when a webcam is
+present, and raises otherwise.
+
+Say plainly when a change could not be verified on real hardware, rather than
+implying it was tested.

--- a/docs/sources/dev/rules.rst
+++ b/docs/sources/dev/rules.rst
@@ -6,7 +6,18 @@ will be updated as we go along.
 
 1. **Conventions**
 
-The ``PEP8`` naming rules are applied.
+The ``PEP8`` naming rules are applied, with a line length limit of 160
+characters rather than 79 — that is what the continuous integration checks.
+
+A few habits are shared by the whole code base. New code is expected to match
+its surroundings rather than modernise them in passing:
+
+- every module starts with the ``# -*- coding: utf-8 -*-`` header
+- logging goes through ``from pibooth.utils import LOGGER``, with lazy
+  arguments — ``LOGGER.info("Loaded %s", name)`` and not a pre-formatted
+  string
+- paths use ``import os.path as osp``
+- strings are formatted with ``"{}".format(...)``
 
 2. **Capture / Picture / Image**
 
@@ -24,3 +35,9 @@ Option relative to a specific state shall have an name starting with the
 state name.
 
 Option relative to a timeout shall have an name ending with ``_delay```.
+
+4. **Plugins naming**
+
+The core plugins expose a ``name`` attribute of the form
+``pibooth-core:<something>``. That name is what ``[GENERAL][plugins_disabled]``
+matches against.

--- a/docs/sources/dev/rules.rst
+++ b/docs/sources/dev/rules.rst
@@ -41,3 +41,10 @@ Option relative to a timeout shall have an name ending with ``_delay```.
 The core plugins expose a ``name`` attribute of the form
 ``pibooth-core:<something>``. That name is what ``[GENERAL][plugins_disabled]``
 matches against.
+
+5. **Contributing a change**
+
+- Keep a change focused. Do not turn a feature change into a repository-wide
+  lint cleanup.
+- Say plainly when a change could not be verified on real hardware, rather than
+  implying it was tested.

--- a/docs/sources/dev/tests.rst
+++ b/docs/sources/dev/tests.rst
@@ -1,0 +1,62 @@
+Running the tests
+-----------------
+
+Install the test dependencies in the environment where ``pibooth`` was installed
+in editable mode (see :ref:`install_developing_version`)::
+
+    pip install pytest pytest-cov flake8 pylint
+    pip install opencv-python
+
+Then run the suite::
+
+    SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest
+
+Both variables matter, for different reasons:
+
+``SDL_VIDEODRIVER=dummy``
+    Makes ``pygame`` render offscreen. Without it, ``pygame`` tries to open a
+    real display and the suite fails to collect. ``tests/test_window.py`` also
+    branches on this variable.
+
+``CAM_VIDEODRIVER``
+    Read only by ``tests/test_camera.py``, which skips every camera test when
+    the variable is **present** — its value is irrelevant. Leave it unset only
+    when a camera is actually connected.
+
+With both set and ``opencv-python`` installed, the whole suite passes on a
+machine without any photobooth hardware, so a failure is a real one. The usual
+cause of a mass failure is a missing ``opencv-python``, which takes out all of
+``tests/test_factory.py``.
+
+Fixtures live in ``tests/conftest.py``. The camera ones — ``camera_rpi``,
+``camera_gp``, ``camera_cv`` and the hybrid variants — are those needing real
+hardware.
+
+``tests/dslr_diag/`` holds ``pibooth-diag`` outputs contributed by users for
+specific DSLR models. They are data files, not tests.
+
+Linters
+^^^^^^^
+
+The continuous integration runs both, but only the first one can fail the
+build::
+
+    flake8 pibooth --count --select=E9,F63,F7,F82 --show-source --statistics
+    flake8 pibooth --count --exit-zero --max-complexity=10 --max-line-length=160 --statistics
+    pylint $(git ls-files '*.py')
+
+The second ``flake8`` invocation and ``pylint`` are informational: the code base
+does not satisfy them today. Do not turn a feature change into a repository-wide
+lint cleanup.
+
+Starting the application
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To exercise the application itself without a photobooth::
+
+    SDL_VIDEODRIVER=dummy pibooth --verbose --nolog /tmp/piboothcfg
+
+``--verbose`` logs every state activation and its duration, which is the main
+tool for debugging the state machine. ``--nolog`` avoids writing
+``/tmp/pibooth.log``, and passing a throwaway configuration directory keeps
+``~/.config/pibooth`` untouched.

--- a/docs/sources/dev/tests.rst
+++ b/docs/sources/dev/tests.rst
@@ -46,8 +46,7 @@ build::
     pylint $(git ls-files '*.py')
 
 The second ``flake8`` invocation and ``pylint`` are informational: the code base
-does not satisfy them today. Do not turn a feature change into a repository-wide
-lint cleanup.
+does not satisfy them today.
 
 Starting the application
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/sources/dev/translations.rst
+++ b/docs/sources/dev/translations.rst
@@ -9,7 +9,7 @@ Keys
 ^^^^
 
 Every language section must define all of them. A missing key falls back to
-English at runtime with a warning, which is a bug rather than a feature.
+English at runtime and logs a warning.
 
 ================== =========================================================
 Key                Where it is displayed

--- a/docs/sources/dev/translations.rst
+++ b/docs/sources/dev/translations.rst
@@ -1,0 +1,80 @@
+Adding a translation
+--------------------
+
+All texts displayed by the interface live in ``pibooth/language.py``, in the
+``DEFAULT`` dictionary keyed by two-letter language code. There is no ``gettext``
+and no ``.po`` file.
+
+Keys
+^^^^
+
+Every language section must define all of them. A missing key falls back to
+English at runtime with a warning, which is a bug rather than a feature.
+
+================== =========================================================
+Key                Where it is displayed
+================== =========================================================
+``intro``          ``wait`` screen, main call to action
+``intro_print``    ``wait`` screen, when the previous picture can be printed
+``choose``         ``choose`` screen title
+``1``              captures number choice — mind the singular and plural
+``2``              idem
+``3``              idem
+``4``              idem
+``chosen``         ``chosen`` screen, confirmation
+``smile``          displayed during ``preview`` and ``capture``
+``processing``     ``processing`` screen
+``print``          ``print`` screen question
+``print_forget``   displayed when the user declines the print
+``finished``       ``finish`` screen
+``oops``           ``failsafe`` screen
+================== =========================================================
+
+Adding a language
+^^^^^^^^^^^^^^^^^
+
+1. Insert a new section in ``DEFAULT``, **in alphabetical order** of the
+   two-letter code users will put in ``[GENERAL][language]``.
+2. Copy the ``en`` block and translate every value, leaving the keys untouched.
+3. Keep the ``\n`` line breaks. They are manual line wrapping for narrow areas
+   of the screen, especially ``intro_print`` and ``print_forget``. Staying close
+   to the number of lines and the line length used by the other languages avoids
+   text overflowing its area.
+4. Add the language to the ``Natural Language ::`` classifiers in ``setup.py``
+   and to the feature list in ``README.rst``.
+
+Nothing else has to be registered: ``get_supported_languages()`` and the
+settings menu pick the new section up automatically.
+
+Things to know
+^^^^^^^^^^^^^^
+
+* Values are plain Python strings, so mind the quoting — an apostrophe forces
+  double quotes, as in ``"C'est parti !"``.
+* The file is UTF-8, so accented and non-latin characters are fine **provided
+  the font can render them**. The default fonts, ``Amatic-Bold`` and
+  ``AmaticSC-Regular``, have a limited coverage: a language using Cyrillic,
+  Greek or CJK characters also requires the user to set ``[WINDOW][font]``.
+* Users can override any text in ``~/.config/pibooth/translations.cfg``, edited
+  with ``pibooth --translate``. Adding a key or a language is not destructive
+  for existing installations: the defaults are merged into the user file.
+
+Checking
+^^^^^^^^
+
+All sections should define exactly the same keys::
+
+    python - <<'EOF'
+    from pibooth.language import DEFAULT
+    reference = set(DEFAULT['en'])
+    for code, texts in DEFAULT.items():
+        missing, extra = reference - set(texts), set(texts) - reference
+        if missing or extra:
+            print(code, 'missing:', missing, 'extra:', extra)
+    EOF
+
+Then regenerate the translations file to see what users will get, without
+touching your own configuration::
+
+    pibooth --reset /tmp/piboothcfg
+    cat /tmp/piboothcfg/translations.cfg


### PR DESCRIPTION
Adds to the developer documentation what a contributor needs but no page describes today.

> **Note** — this PR previously added a `CLAUDE.md` and five skill files under `.claude/`. That approach was dropped: 652 lines specific to a single tool, in a repository that contains none, duplicating pages that already exist. The content that had value has been rewritten as ordinary documentation, useful whatever editor you work with. The branch was rebuilt on `master`, so the diff is documentation only.

## What is added

**`docs/sources/dev/architecture.rst`** — module layout, and the two contracts that are easy to get wrong:

- a state transition only ever happens because a `state_<name>_validate` hook returned a state name
- **the plugins call order**, which is the recurring source of confusion for plugin authors: core plugins are registered last so they are called *first*, and the `_validate` hooks are `firstresult=True`, so the first non-`None` result wins. An external plugin therefore cannot prevent a transition a core plugin has already decided — returning `None` from `state_finish_validate` does not keep the application on the finish screen, because `ViewPlugin` has already returned `'wait'`. This is exactly the behaviour reported in #643, and it was documented nowhere.

The page also records that `hookspecs.py` is a public API consumed by plugins published on PyPI (adding is compatible, renaming or removing is not), describes `DEFAULT` as the single source of truth for the configuration along with the hand-maintained `default.cfg`, and lists what simply cannot run outside a Raspberry Pi.

It cross-references `plugins.rst` for the states and the four hooks rather than restating them — avoiding duplication is the point of this PR.

**`docs/sources/dev/tests.rst`** — how to run the suite. `SDL_VIDEODRIVER=dummy` is required for pygame to render offscreen, while `CAM_VIDEODRIVER` merely *skips* the camera tests and is ignored by the application. The two look interchangeable and are not. Also: `opencv-python` is needed or `test_factory.py` fails wholesale, and of the three linter invocations only the first can fail the build.

**`docs/sources/dev/translations.rst`** — adding a language. Translations come from the community and no page explained how: the key table and where each string appears, the `\n` that are manual line wrapping for the screen, the files to update besides `language.py`, and a consistency check.

**`docs/sources/dev/rules.rst`** — the conventions the code base actually follows: lazy `LOGGER` arguments, `import os.path as osp`, `.format()`, the 160-character limit the CI really enforces, and the `pibooth-core:<x>` naming of core plugins.

**`docs/index.rst`** — the three pages in the toctree, and the `python-3.6+` badge aligned with the supported versions (#663 only updated the one in the README).

## Verification

Every command quoted in these pages was executed, not assumed:

| Check | Result |
|---|---|
| `SDL_VIDEODRIVER=dummy CAM_VIDEODRIVER=dummy pytest` | 84 passed, 5 skipped |
| blocking `flake8` invocation | 0 |
| translation consistency check | no missing or extra key in any of the 12 languages |
| `diff` between a generated `pibooth.cfg` and `default.cfg` | identical apart from the trailing newline, as documented |
| Sphinx build | no warning, cross-references to `plugins.rst` and `hooks.rst` resolve |

## Independent

Documentation only — no dependency on #663, #664, #665 or #666, and no file in common with them.