### PR TITLE
Check in CI that the built package actually installs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,3 +47,37 @@ jobs:
         pytest --cov pibooth
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+
+  package:
+    # Checks what a user actually receives: the built wheel, installed in an
+    # empty environment. The job above installs in editable mode on a runner
+    # that already has the dependencies resolved, so it cannot catch a
+    # dependency that has no installable release for a given Python version.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Build the wheel
+      run: |
+        python -m pip install --upgrade pip build twine
+        python -m build --wheel .
+        twine check dist/*
+    - name: Install the wheel in a clean environment
+      run: |
+        python -m venv /tmp/install-check
+        /tmp/install-check/bin/pip install dist/pibooth-*.whl
+    - name: Start the installed application
+      env:
+        SDL_VIDEODRIVER: dummy
+      run: |
+        /tmp/install-check/bin/pibooth --reset /tmp/cfg-check
+        test -f /tmp/cfg-check/pibooth.cfg
+        test -f /tmp/cfg-check/translations.cfg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,10 +49,6 @@ jobs:
       uses: codecov/codecov-action@v3
 
   package:
-    # Checks what a user actually receives: the built distributions, installed
-    # in an empty environment. The job above installs in editable mode on a
-    # runner that already has the dependencies resolved, so it cannot catch a
-    # dependency that has no installable release for a given Python version.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -68,10 +64,7 @@ jobs:
     - name: Build the source distribution and the wheel
       run: |
         python -m pip install --upgrade pip build twine
-        # Not --wheel: build the sdist, then the wheel *from that sdist*, so a
-        # file missing from MANIFEST.in fails here instead of on PyPI.
         python -m build .
-        # --strict so a malformed long_description fails instead of warning.
         twine check --strict dist/*
     - name: Install the wheel in a clean environment
       run: |
@@ -81,14 +74,11 @@ jobs:
       env:
         SDL_VIDEODRIVER: dummy
       run: |
-        # --reset regenerates the configuration files and exits, but it imports
-        # every declared runtime dependency along the way.
         "$RUNNER_TEMP/install-check/bin/pibooth" --reset "$RUNNER_TEMP/cfg-check"
         test -f "$RUNNER_TEMP/cfg-check/pibooth.cfg"
         test -f "$RUNNER_TEMP/cfg-check/translations.cfg"
     - name: Check the data files shipped with the wheel
       run: |
-        # A missing package_data entry installs fine and only fails at runtime.
         SITE=$("$RUNNER_TEMP/install-check/bin/python" -c \
                "import pibooth, os.path as osp; print(osp.dirname(pibooth.__file__))")
         ls "$SITE"/fonts/*.ttf > /dev/null
@@ -97,8 +87,6 @@ jobs:
       env:
         SDL_VIDEODRIVER: dummy
       run: |
-        # pibooth-diag and pibooth-printcfg are left out on purpose: they need
-        # the 'dslr' and 'printer' extras, which a bare install does not pull in.
         for script in pibooth-count pibooth-fonts pibooth-regen; do
           "$RUNNER_TEMP/install-check/bin/$script" --help > /dev/null
         done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,9 +49,9 @@ jobs:
       uses: codecov/codecov-action@v3
 
   package:
-    # Checks what a user actually receives: the built wheel, installed in an
-    # empty environment. The job above installs in editable mode on a runner
-    # that already has the dependencies resolved, so it cannot catch a
+    # Checks what a user actually receives: the built distributions, installed
+    # in an empty environment. The job above installs in editable mode on a
+    # runner that already has the dependencies resolved, so it cannot catch a
     # dependency that has no installable release for a given Python version.
     runs-on: ubuntu-latest
     strategy:
@@ -65,19 +65,40 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Build the wheel
+    - name: Build the source distribution and the wheel
       run: |
         python -m pip install --upgrade pip build twine
-        python -m build --wheel .
-        twine check dist/*
+        # Not --wheel: build the sdist, then the wheel *from that sdist*, so a
+        # file missing from MANIFEST.in fails here instead of on PyPI.
+        python -m build .
+        # --strict so a malformed long_description fails instead of warning.
+        twine check --strict dist/*
     - name: Install the wheel in a clean environment
       run: |
-        python -m venv /tmp/install-check
-        /tmp/install-check/bin/pip install dist/pibooth-*.whl
-    - name: Start the installed application
+        python -m venv "$RUNNER_TEMP/install-check"
+        "$RUNNER_TEMP/install-check/bin/pip" install dist/*.whl
+    - name: Smoke-test the installed application
       env:
         SDL_VIDEODRIVER: dummy
       run: |
-        /tmp/install-check/bin/pibooth --reset /tmp/cfg-check
-        test -f /tmp/cfg-check/pibooth.cfg
-        test -f /tmp/cfg-check/translations.cfg
+        # --reset regenerates the configuration files and exits, but it imports
+        # every declared runtime dependency along the way.
+        "$RUNNER_TEMP/install-check/bin/pibooth" --reset "$RUNNER_TEMP/cfg-check"
+        test -f "$RUNNER_TEMP/cfg-check/pibooth.cfg"
+        test -f "$RUNNER_TEMP/cfg-check/translations.cfg"
+    - name: Check the data files shipped with the wheel
+      run: |
+        # A missing package_data entry installs fine and only fails at runtime.
+        SITE=$("$RUNNER_TEMP/install-check/bin/python" -c \
+               "import pibooth, os.path as osp; print(osp.dirname(pibooth.__file__))")
+        ls "$SITE"/fonts/*.ttf > /dev/null
+        ls "$SITE"/pictures/*/*.png > /dev/null
+    - name: Check the other console scripts
+      env:
+        SDL_VIDEODRIVER: dummy
+      run: |
+        # pibooth-diag and pibooth-printcfg are left out on purpose: they need
+        # the 'dslr' and 'printer' extras, which a bare install does not pull in.
+        for script in pibooth-count pibooth-fonts pibooth-regen; do
+          "$RUNNER_TEMP/install-check/bin/$script" --help > /dev/null
+        done

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-include README.rst
-include LICENSE
 include docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include README.rst
 include LICENSE
-# Read by setup.py at build time: without it the sdist cannot be built into a wheel
 include docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include LICENSE
+# Read by setup.py at build time: without it the sdist cannot be built into a wheel
+include docs/requirements.txt


### PR DESCRIPTION
Second step towards 2.1.0: CI installs the project with `pip install -e .`, on a runner where the dependencies already resolve. That is not what a user receives, which is how `pip install pibooth` could stay broken on Python 3.12+ for years while CI was green (#654, #657, #603, #663).

## What changed

A new **`package` job** doing what a user does, on 3.10 → 3.13, without `opencv-python` or any test tooling so it exercises the bare dependency set from `setup.py`:

1. `python -m build` — not `--wheel`, so the wheel is built *from the sdist* and a file missing from the sdist fails here rather than on PyPI. Then `twine check --strict`.
2. Install the wheel into an empty venv.
3. `pibooth --reset`, which imports every declared runtime dependency, then assert the config files exist.
4. Assert the `package_data` files shipped, and `--help` the console scripts. `pibooth-diag` and `pibooth-printcfg` are excluded: they need the `dslr` and `printer` extras.

Also **`MANIFEST.in`**, because building the sdist showed it is already broken on `master`: `setup.py` reads `docs/requirements.txt` at build time and it was not shipped, so `pip install --no-binary` and any downstream rebuild fail. Enabling the sdist build without this fix would just turn CI red.

## Verification

All four versions are covered by CI; the job in its current form was reproduced locally on 3.11. Both guards were also checked in reverse: removing `MANIFEST.in` fails the build step, and restoring `Pillow==9.2.0` fails the install step on 3.12 — while the wheel still builds and `twine check` still passes, which is why a build-and-check job alone would not have caught it.

## Note on #663

#663 raises `python_requires` to `&gt;=3.10`, so the matrix update and action bumps live there. Each PR goes green on its own; whichever lands second needs a trivial rebase on `tests.yml`.