### PR TITLE
Document an install procedure that works since Bookworm

### DIFF
--- a/docs/sources/dev/install.rst
+++ b/docs/sources/dev/install.rst
@@ -6,7 +6,7 @@ Install developing version
 .. warning:: Be aware that the code on the `master` branch may be unstable.
 
 If you want to use an **unofficial version** of the ``pibooth`` application, you
-need to work from a clone of this ``git`` repository. Replace the step 8. of the
+need to work from a clone of this ``git`` repository. Replace the step 9. of the
 :ref:`install` procedure by the following actions:
 
 1. Clone from github :
@@ -21,12 +21,19 @@ need to work from a clone of this ``git`` repository. Replace the step 8. of the
 
     cd pibooth
 
-3. Install ``pibooth`` in editable mode :
+3. Create a virtual environment and install ``pibooth`` in editable mode in it:
 
 .. code-block:: bash
 
-    sudo pip3 install -e .[dslr,printer]
+    python3 -m venv --system-site-packages .venv
+    .venv/bin/pip install -e .[dslr,printer]
 
-4. Start the application exactly in the same way as installed from pypi. All
-   modifications performed in the cloned repository are taken into account when
-   the application starts.
+.. note:: Installing with ``sudo pip3 install -e .`` no longer works: since
+          Bookworm the system Python is *externally managed* (:pep:`668`) and
+          ``pip`` refuses to write into it. ``--system-site-packages`` keeps
+          ``python3-opencv`` installed with ``apt`` visible from the virtual
+          environment.
+
+4. Start the application with ``.venv/bin/pibooth``, exactly in the same way as
+   installed from pypi. All modifications performed in the cloned repository are
+   taken into account when the application starts.

--- a/docs/sources/dev/install.rst
+++ b/docs/sources/dev/install.rst
@@ -6,7 +6,7 @@ Install developing version
 .. warning:: Be aware that the code on the `master` branch may be unstable.
 
 If you want to use an **unofficial version** of the ``pibooth`` application, you
-need to work from a clone of this ``git`` repository. Replace the step 9. of the
+need to work from a clone of this ``git`` repository. Replace the step 8. of the
 :ref:`install` procedure by the following actions:
 
 1. Clone from github :

--- a/docs/sources/dev/install.rst
+++ b/docs/sources/dev/install.rst
@@ -30,8 +30,9 @@ need to work from a clone of this ``git`` repository. Replace the step 8. of the
 
 .. note:: Installing with ``sudo pip3 install -e .`` no longer works: since
           Bookworm the system Python is *externally managed* (:pep:`668`) and
-          ``pip`` refuses to write into it. ``--system-site-packages`` keeps
-          ``python3-opencv`` installed with ``apt`` visible from the virtual
+          ``pip`` refuses to write into it. ``--system-site-packages`` keeps the
+          libraries installed with ``apt`` — ``python3-opencv``,
+          ``python3-picamera2``, the GPIO ones — visible from the virtual
           environment.
 
 4. Start the application with ``.venv/bin/pibooth``, exactly in the same way as

--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -151,6 +151,33 @@ Manual procedure
 
                      [ INFO    ] pibooth: Installed plugins: qrcode-1.0.2
 
+11. If you use the hardware buttons and LEDs, check that ``pibooth`` can reach
+    the GPIO. Start it once and read the first log line:
+
+    .. code-block:: bash
+
+         pibooth --verbose
+
+    ``pibooth`` reports which GPIO backend it obtained::
+
+         [ INFO    ] pibooth: Starting the photo booth application on Raspberry pi 4B
+
+    If it reports this instead, no GPIO backend could be loaded and the buttons
+    and LEDs will do nothing::
+
+         [ INFO    ] pibooth: Starting the photo booth application without physical GPIO, fallback to GPIO mock
+
+    ``pibooth`` drives the GPIO through `gpiozero
+    <https://gpiozero.readthedocs.io>`_, which looks for a backend at startup
+    and tries ``lgpio``, ``RPi.GPIO``, ``pigpio``, then a pure Python fallback.
+    Raspberry Pi OS ships those libraries in the **system** Python, which is
+    precisely why step 9. passes ``--system-site-packages``: without it, the
+    isolated environment cannot see them and falls back to the mock.
+
+    .. note:: This line only tells you that a backend was loaded. It does not
+              prove the wiring works — press both buttons and check that both
+              LEDs light up.
+
 Using a virtual environment instead
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -38,8 +38,8 @@ Software
           behaves differently on it.
 
 .. note:: Since Bookworm, the system Python is *externally managed*
-          (:pep:`668`): ``pip`` refuses to install into it. The procedure below
-          therefore installs ``pibooth`` in its own isolated environment.
+          (:pep:`668`), which changes how ``pibooth`` has to be installed. Two
+          methods are given at step 8., see :ref:`which_install_method`.
 
 
 Install
@@ -48,7 +48,7 @@ Install
 Here is a brief description on how to set-up a Raspberry Pi to use this software.
 
 If you intend to develop on ``pibooth``, an editable/customizable version can be
-installed. Instead of doing step 9. of the below procedure, follow
+installed. Instead of doing step 8. of the below procedure, follow
 :ref:`instructions here<install_developing_version>`.
 
 Manual procedure
@@ -101,57 +101,58 @@ Manual procedure
 
         sudo apt-get install python3-opencv
 
-8. Install ``pipx``, which installs a Python application in its own isolated
-   environment while keeping its commands available system-wide:
+8. Install ``pibooth`` from the `pypi repository <https://pypi.org/project/pibooth/>`_.
+   Pick the method matching how the Raspberry Pi is used — see
+   :ref:`which_install_method` if you are unsure:
+
+   **a. The Raspberry Pi is dedicated to the photobooth**
 
    .. code-block:: bash
 
-        sudo apt-get install pipx
-        pipx ensurepath
+        sudo pip3 install --break-system-packages pibooth[dslr,printer]
 
-   .. note:: ``pipx ensurepath`` adds ``~/.local/bin`` to your ``PATH``. Open a
-             new terminal afterwards, otherwise the ``pibooth`` command will not
-             be found.
-
-9. Install ``pibooth`` from the `pypi repository <https://pypi.org/project/pibooth/>`_:
+   **b. The Raspberry Pi is also used for something else**
 
    .. code-block:: bash
 
-        pipx install --system-site-packages pibooth[dslr,printer]
+        python3 -m venv --system-site-packages ~/pibooth-venv
+        ~/pibooth-venv/bin/pip install pibooth[dslr,printer]
 
-   .. warning:: ``--system-site-packages`` is required if you installed
-                ``OpenCV`` with ``apt`` at step 7. Without it, the isolated
-                environment cannot see ``python3-opencv`` and the webcam
-                will not be detected.
+   The application then starts with ``~/pibooth-venv/bin/pibooth`` instead of
+   ``pibooth``.
+
+   .. warning:: ``--system-site-packages`` is not optional. Without it the
+                virtual environment cannot see the libraries installed with
+                ``apt`` — ``python3-opencv`` from step 7., and the GPIO
+                libraries — so the webcam is not detected and the buttons and
+                LEDs stay inert.
 
    .. hint:: If you don't have ``gPhoto2`` and/or ``CUPS`` installed (steps 5. and/
           or 6. skipped), remove **printer** and/or **dslr** under the ``[]``.
 
           As a consequence if you only want to use gphoto2 (step 6 skipped):
 
-          ``pipx install --system-site-packages pibooth[dslr]``
+          ``sudo pip3 install --break-system-packages pibooth[dslr]``
 
           Or if you only want to use the printer (step 5 skipped):
 
-          ``pipx install --system-site-packages pibooth[printer]``
+          ``sudo pip3 install --break-system-packages pibooth[printer]``
 
-          The classic command ``pipx install --system-site-packages pibooth`` will install ``pibooth`` without these two dependencies (step 5 and 6 skipped).
+          The classic command ``sudo pip3 install --break-system-packages pibooth`` will install ``pibooth`` without these two dependencies (step 5 and 6 skipped).
 
-10. Install the plugins you want, **into the same environment**:
+9. Install the plugins you want, with the ``pip`` of the method chosen above:
 
-    .. code-block:: bash
+   .. code-block:: bash
 
-         pipx inject pibooth pibooth-qrcode
+        sudo pip3 install --break-system-packages pibooth-qrcode
+        # or, with a virtual environment
+        ~/pibooth-venv/bin/pip install pibooth-qrcode
 
-    .. warning:: Do not use ``pip install`` for plugins. ``pibooth`` discovers
-                 them through its own environment, so a plugin installed
-                 elsewhere is simply ignored. ``pipx inject`` puts it in the
-                 right place. Check the startup log, which lists what was
-                 actually loaded::
+   The startup log lists what was actually loaded::
 
-                     [ INFO    ] pibooth: Installed plugins: qrcode-1.0.2
+        [ INFO    ] pibooth: Installed plugins: qrcode-1.0.2
 
-11. If you use the hardware buttons and LEDs, check that ``pibooth`` can reach
+10. If you use the hardware buttons and LEDs, check that ``pibooth`` can reach
     the GPIO. Start it once and read the first log line:
 
     .. code-block:: bash
@@ -170,34 +171,40 @@ Manual procedure
     ``pibooth`` drives the GPIO through `gpiozero
     <https://gpiozero.readthedocs.io>`_, which looks for a backend at startup
     and tries ``lgpio``, ``RPi.GPIO``, ``pigpio``, then a pure Python fallback.
-    Raspberry Pi OS ships those libraries in the **system** Python, which is
-    precisely why step 9. passes ``--system-site-packages``: without it, the
-    isolated environment cannot see them and falls back to the mock.
+    Raspberry Pi OS ships those libraries in the **system** Python, so they are
+    always reachable with method **a**, and only reachable with method **b**
+    thanks to ``--system-site-packages``.
 
     .. note:: This line only tells you that a backend was loaded. It does not
               prove the wiring works — press both buttons and check that both
               LEDs light up.
 
-Using a virtual environment instead
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _which_install_method:
 
-If you prefer not to use ``pipx``, an explicit virtual environment works the
-same way. Note the ``--system-site-packages`` flag, needed for the same reason
-as above:
+Which installation method?
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+Since Bookworm, the system Python is *externally managed* (:pep:`668`):
+``pip`` refuses to install into it unless ``--break-system-packages`` is
+passed. That flag is not as brutal as its name suggests, but it is not free
+either.
 
-     python3 -m venv --system-site-packages ~/pibooth-venv
-     ~/pibooth-venv/bin/pip install pibooth[dslr,printer]
-     ~/pibooth-venv/bin/pip install pibooth-qrcode
+``pip`` installs into ``/usr/local/lib/python3.X/dist-packages``, which comes
+**before** the ``/usr/lib/python3/dist-packages`` used by ``apt`` in the
+search path. So the libraries pulled by ``pibooth`` take precedence over the
+ones packaged by Debian, for every program using the system Python. Nothing is
+deleted and ``apt`` itself stays consistent — the effect is reversible by
+uninstalling — but another Python application on the same machine may silently
+end up running a version it was not tested against.
 
-Start the application with ``~/pibooth-venv/bin/pibooth``.
+On a Raspberry Pi dedicated to the photobooth there is nothing else to
+disturb, and method **a** keeps everything simple: ``apt`` libraries are
+natively visible, plugins install with a plain ``pip install``, and the
+``pibooth`` command is available system-wide.
 
-.. warning:: You may find ``sudo pip3 install --break-system-packages pibooth``
-             suggested as a workaround. It installs ``pibooth`` and its
-             dependencies straight into the system Python, where they can
-             conflict with packages managed by ``apt`` and break unrelated
-             system tools. Prefer one of the two methods above.
+On a Raspberry Pi doing other things, method **b** confines ``pibooth`` and
+its dependencies to a single directory, at the cost of typing the full path to
+the application.
 
 Automated procedure
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -27,11 +27,19 @@ Hardware
 Software
 ^^^^^^^^
 
-* Raspberry Pi OS **Buster** (32 bit) with desktop (`could be downloaded here <https://downloads.raspberrypi.org/raspios_oldstable_armhf/images/>`_)
-* Python ``3.7.3``
+* Raspberry Pi OS **Bookworm** (64 bit) with desktop (`could be downloaded here <https://www.raspberrypi.com/software/operating-systems/>`_)
+* Python ``3.10`` or higher
 * libsdl2 ``2.0``
 * libgphoto2 ``2.5.27``
 * libcups ``2.2.10``
+
+.. note:: Raspberry Pi OS **Trixie** has not been validated yet. Users have
+          reported that ``sudo apt-get install libsdl2-*`` (step 4. below)
+          behaves differently on it.
+
+.. note:: Since Bookworm, the system Python is *externally managed*
+          (:pep:`668`): ``pip`` refuses to install into it. The procedure below
+          therefore installs ``pibooth`` in its own isolated environment.
 
 
 Install
@@ -40,7 +48,7 @@ Install
 Here is a brief description on how to set-up a Raspberry Pi to use this software.
 
 If you intend to develop on ``pibooth``, an editable/customizable version can be
-installed. Instead of doing step 8. of the below procedure, follow
+installed. Instead of doing step 9. of the below procedure, follow
 :ref:`instructions here<install_developing_version>`.
 
 Manual procedure
@@ -93,24 +101,76 @@ Manual procedure
 
         sudo apt-get install python3-opencv
 
-8. Install ``pibooth`` from the `pypi repository <https://pypi.org/project/pibooth/>`_:
+8. Install ``pipx``, which installs a Python application in its own isolated
+   environment while keeping its commands available system-wide:
 
    .. code-block:: bash
 
-        sudo pip3 install pibooth[dslr,printer]
+        sudo apt-get install pipx
+        pipx ensurepath
+
+   .. note:: ``pipx ensurepath`` adds ``~/.local/bin`` to your ``PATH``. Open a
+             new terminal afterwards, otherwise the ``pibooth`` command will not
+             be found.
+
+9. Install ``pibooth`` from the `pypi repository <https://pypi.org/project/pibooth/>`_:
+
+   .. code-block:: bash
+
+        pipx install --system-site-packages pibooth[dslr,printer]
+
+   .. warning:: ``--system-site-packages`` is required if you installed
+                ``OpenCV`` with ``apt`` at step 7. Without it, the isolated
+                environment cannot see ``python3-opencv`` and the webcam
+                will not be detected.
 
    .. hint:: If you don't have ``gPhoto2`` and/or ``CUPS`` installed (steps 5. and/
           or 6. skipped), remove **printer** and/or **dslr** under the ``[]``.
 
           As a consequence if you only want to use gphoto2 (step 6 skipped):
 
-          ``sudo pip3 install pibooth[dslr]`` 
-          
+          ``pipx install --system-site-packages pibooth[dslr]``
+
           Or if you only want to use the printer (step 5 skipped):
 
-          ``sudo pip3 install pibooth[printer]``
+          ``pipx install --system-site-packages pibooth[printer]``
 
-          The classic command ``sudo pip3 install pibooth`` will install ``pibooth`` without these two dependencies (step 5 and 6 skipped).
+          The classic command ``pipx install --system-site-packages pibooth`` will install ``pibooth`` without these two dependencies (step 5 and 6 skipped).
+
+10. Install the plugins you want, **into the same environment**:
+
+    .. code-block:: bash
+
+         pipx inject pibooth pibooth-qrcode
+
+    .. warning:: Do not use ``pip install`` for plugins. ``pibooth`` discovers
+                 them through its own environment, so a plugin installed
+                 elsewhere is simply ignored. ``pipx inject`` puts it in the
+                 right place. Check the startup log, which lists what was
+                 actually loaded::
+
+                     [ INFO    ] pibooth: Installed plugins: qrcode-1.0.2
+
+Using a virtual environment instead
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you prefer not to use ``pipx``, an explicit virtual environment works the
+same way. Note the ``--system-site-packages`` flag, needed for the same reason
+as above:
+
+.. code-block:: bash
+
+     python3 -m venv --system-site-packages ~/pibooth-venv
+     ~/pibooth-venv/bin/pip install pibooth[dslr,printer]
+     ~/pibooth-venv/bin/pip install pibooth-qrcode
+
+Start the application with ``~/pibooth-venv/bin/pibooth``.
+
+.. warning:: You may find ``sudo pip3 install --break-system-packages pibooth``
+             suggested as a workaround. It installs ``pibooth`` and its
+             dependencies straight into the system Python, where they can
+             conflict with packages managed by ``apt`` and break unrelated
+             system tools. Prefer one of the two methods above.
 
 Automated procedure
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/sources/install.rst
+++ b/docs/sources/install.rst
@@ -94,12 +94,19 @@ Manual procedure
 
         sudo apt-get install cups libcups2-dev
 
-7. Optionally install ``OpenCV`` to improve images generation efficiency or if a
-   Webcam is used:
+7. Install the camera libraries you need. ``OpenCV`` also improves images
+   generation efficiency, whichever camera is used:
 
    .. code-block:: bash
 
-        sudo apt-get install python3-opencv
+        sudo apt-get install python3-opencv      # webcam, and faster images generation
+        sudo apt-get install python3-picamera2   # Raspberry Pi camera
+
+   .. note:: ``python3-picamera2`` is already present on the Raspberry Pi OS
+             desktop images. Install it with ``apt`` and not with ``pip``: two
+             of its dependencies ship no pre-built package, so ``pip`` would
+             have to compile them, and the ``libcamera`` binding it needs is not
+             published on PyPI at all.
 
 8. Install ``pibooth`` from the `pypi repository <https://pypi.org/project/pibooth/>`_.
    Pick the method matching how the Raspberry Pi is used — see
@@ -123,9 +130,8 @@ Manual procedure
 
    .. warning:: ``--system-site-packages`` is not optional. Without it the
                 virtual environment cannot see the libraries installed with
-                ``apt`` — ``python3-opencv`` from step 7., and the GPIO
-                libraries — so the webcam is not detected and the buttons and
-                LEDs stay inert.
+                ``apt`` — those of step 7. and the GPIO ones — so no camera is
+                detected and the buttons and LEDs stay inert.
 
    .. hint:: If you don't have ``gPhoto2`` and/or ``CUPS`` installed (steps 5. and/
           or 6. skipped), remove **printer** and/or **dslr** under the ``[]``.


### PR DESCRIPTION
## Why

The install page targeted **Raspberry Pi OS Buster 32-bit** and **Python 3.7.3**, and told users to run `sudo pip3 install pibooth[dslr,printer]`. Since Bookworm the system Python is externally managed ([PEP 668](https://peps.python.org/pep-0668/)), so that command fails outright. With no supported path documented, users improvised — see #654, #657, #603 and #638.

Documentation only, no code change.

## What changed

### `docs/sources/install.rst`

- **Prerequisites refreshed**: Bookworm 64-bit instead of Buster 32-bit, Python `3.10` or higher instead of `3.7.3`, and a download link that still works (#638). Trixie is flagged as not validated (#654).
- **Step 7** now covers both cameras — `python3-opencv` and `python3-picamera2` — and says why they come from `apt` rather than `pip`: two dependencies ship no pre-built package and the `libcamera` binding is not published on PyPI.
- **Step 8** gives two install methods, chosen by how the Raspberry Pi is used:
  - **a. dedicated to the photobooth** — system-wide with `--break-system-packages`;
  - **b. shared with other uses** — a virtual environment created with `--system-site-packages`, the application then starting with `~/pibooth-venv/bin/pibooth`.

  A warning states that `--system-site-packages` is not optional: without it, no camera is detected and the buttons and LEDs stay inert. The existing hint about `[dslr]` / `[printer]` follows the same commands.
- **Step 9** (new): installing plugins with the `pip` of the method chosen above, plus the startup log line that lists what was actually loaded.
- **Step 10** (new): checking the GPIO backend from the startup log, and what the fallback line means.
- **New section "Which installation method?"**, referenced from the prerequisites and from step 8: what `--break-system-packages` actually costs. `pip` installs into `/usr/local/lib/python3.X/dist-packages`, which precedes the `apt` directory in the search path, so pibooth's libraries take precedence for every program using the system Python. Nothing is deleted, `apt` stays consistent and the effect is reversible — but another application may end up running a version it was not tested against. On a dedicated photobooth there is nothing else to disturb; on a shared machine there is.

### `docs/sources/dev/install.rst`

- The editable install moves from `sudo pip3 install -e .[dslr,printer]` to a virtual environment created with `--system-site-packages`, with a note explaining why, and the start command becomes `.venv/bin/pibooth`.

## Verification

Every documented command was executed, and the Sphinx build is clean (procedure numbered 1→10, cross-reference resolved).

| Check | Result |
|---|---|
| system-wide install of the wheel | ✅ script at `/usr/local/bin/pibooth`, `--version` → `2.0.8` |
| packages land where the new section claims | ✅ `/usr/local/lib/python3.11/dist-packages` |
| plugin with a plain `pip install` | ✅ `Installed plugins: qrcode-1.0.2` at startup |
| virtual environment install | ✅ `cv2` visible, application starts |
| `cv2` without `--system-site-packages` | `ModuleNotFoundError` — the failure step 8. warns about |
| developer editable route | ✅ installs, application starts |

The GPIO check documented at step 10. could not be verified on x86_64: it was reasoned from gpiozero's source, and the `--system-site-packages` mechanism was verified with `cv2` instead. On a Pi, `pibooth --verbose` should report `... on Raspberry pi <model>`; if it reports `... without physical GPIO, fallback to GPIO mock`, that step needs adjusting.
