### PR TITLE
Write an absolute path in the auto-startup file

### DIFF
--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -9,6 +9,9 @@ import os
 import os.path as osp
 import itertools
 import inspect
+import shlex
+import shutil
+import sys
 from configparser import RawConfigParser
 from collections import OrderedDict as odict
 from pibooth.utils import LOGGER, open_text_editor
@@ -19,6 +22,37 @@ def values_list_repr(values):
     """Concatenate a list of values to a readable string.
     """
     return "'{}' or '{}'".format("', '".join([str(i) for i in values[:-1]]), values[-1])
+
+
+def get_launch_command():
+    """Return the command to start pibooth, as an absolute path when it can be
+    resolved.
+
+    The auto-startup file is read by the desktop session, which does not
+    necessarily share the PATH of the shell pibooth was installed from. An
+    absolute path is therefore required when pibooth lives in a virtual
+    environment, and harmless when it is installed system-wide.
+    """
+    # Console scripts sit next to the interpreter of their environment
+    command = osp.join(osp.dirname(sys.executable), 'pibooth')
+    if osp.isfile(command):
+        return command
+    # Started as 'python -m pibooth.booth', fallback to a PATH lookup
+    return shutil.which('pibooth') or 'pibooth'
+
+
+def desktop_quote(arg):
+    """Quote an argument for the ``Exec`` key of a desktop entry file.
+
+    Desktop entries do not use shell quoting: single quotes have no special
+    meaning there. Reserved characters have to be enclosed in double quotes,
+    a few of them being additionally escaped with a backslash.
+    """
+    if not any(char in arg for char in ' \t\n"\'\\><~|&;$*?#()`'):
+        return arg
+    for char in ('\\', '"', '`', '$'):  # backslash first, it escapes the others
+        arg = arg.replace(char, '\\' + char)
+    return '"{}"'.format(arg)
 
 
 DEFAULT = odict((
@@ -331,12 +365,25 @@ class PiConfigParser(RawConfigParser):
         enable = self.getboolean('GENERAL', 'autostart')
         delay = self.getint('GENERAL', 'autostart_delay')
         if enable:
+            command = get_launch_command()
+            content = "[Desktop Entry]\nName=pibooth\n"
+            if delay > 0:
+                # The whole shell snippet is a single argument of 'bash -c',
+                # quoted for the desktop entry, and the command inside it
+                # quoted for the shell that will run it.
+                content += "Exec=bash -c {}\n".format(
+                    desktop_quote("sleep {} && {}".format(delay, shlex.quote(command))))
+            else:
+                content += "Exec={}\n".format(desktop_quote(command))
+            content += "Type=application\n"
+
             regenerate = True
             if osp.isfile(filename):
                 with open(filename, 'r') as fp:
-                    txt = fp.read()
-                    if delay > 0 and f"sleep {delay}" in txt or delay <= 0 and "sleep" not in txt:
-                        regenerate = False
+                    # Rewrite as soon as anything differs: the delay may have
+                    # changed, but so may the path to the executable if pibooth
+                    # was re-installed somewhere else.
+                    regenerate = fp.read() != content
 
             if regenerate:
                 if not osp.isdir(dirname):
@@ -344,13 +391,7 @@ class PiConfigParser(RawConfigParser):
 
                 LOGGER.info("Generate the auto-startup file in '%s'", dirname)
                 with open(filename, 'w') as fp:
-                    fp.write("[Desktop Entry]\n")
-                    fp.write("Name=pibooth\n")
-                    if delay > 0:
-                        fp.write(f"Exec=bash -c \"sleep {delay} && pibooth\"\n")
-                    else:
-                        fp.write("Exec=pibooth\n")
-                    fp.write("Type=application\n")
+                    fp.write(content)
 
         elif not enable and osp.isfile(filename):
             LOGGER.info("Remove the auto-startup file in '%s'", dirname)

--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -26,34 +26,25 @@ def values_list_repr(values):
 
 def get_launch_command():
     """Return the command to start pibooth, as an absolute path when it can be
-    resolved.
-
-    The auto-startup file is read by the desktop session, which does not
-    necessarily share the PATH of the shell pibooth was installed from. An
-    absolute path is therefore required when pibooth lives in a virtual
-    environment, and harmless when it is installed system-wide.
+    resolved. The desktop session reading the auto-startup file does not
+    necessarily share the PATH of the shell pibooth was installed from.
     """
-    # Console scripts sit next to the interpreter of their environment
     command = osp.join(osp.dirname(sys.executable), 'pibooth')
     if osp.isfile(command):
         return command
-    # Started as 'python -m pibooth.booth', fallback to a PATH lookup
     return shutil.which('pibooth') or 'pibooth'
 
 
 def desktop_quote(arg):
-    """Quote an argument for the ``Exec`` key of a desktop entry file.
-
-    Desktop entries do not use shell quoting: single quotes have no special
-    meaning there. Reserved characters have to be enclosed in double quotes,
-    a few of them being additionally escaped with a backslash.
+    """Quote an argument for the ``Exec`` key of a desktop entry file. Desktop
+    entries do not use shell quoting: reserved characters are enclosed in double
+    quotes, a few of them escaped with a backslash, and '%' is doubled to not be
+    read as a field code.
     """
-    # A literal percent sign is written '%%', quoted or not, else it would be
-    # read as one of the field codes ('%f', '%U', ...) expanded by the launcher
     arg = arg.replace('%', '%%')
     if not any(char in arg for char in ' \t\n"\'\\><~|&;$*?#()`'):
         return arg
-    for char in ('\\', '"', '`', '$'):  # backslash first, it escapes the others
+    for char in ('\\', '"', '`', '$'):
         arg = arg.replace(char, '\\' + char)
     return '"{}"'.format(arg)
 
@@ -371,9 +362,6 @@ class PiConfigParser(RawConfigParser):
             command = get_launch_command()
             content = "[Desktop Entry]\nName=pibooth\n"
             if delay > 0:
-                # The whole shell snippet is a single argument of 'bash -c',
-                # quoted for the desktop entry, and the command inside it
-                # quoted for the shell that will run it.
                 content += "Exec=bash -c {}\n".format(
                     desktop_quote("sleep {} && {}".format(delay, shlex.quote(command))))
             else:
@@ -383,9 +371,6 @@ class PiConfigParser(RawConfigParser):
             regenerate = True
             if osp.isfile(filename):
                 with open(filename, 'r') as fp:
-                    # Rewrite as soon as anything differs: the delay may have
-                    # changed, but so may the path to the executable if pibooth
-                    # was re-installed somewhere else.
                     regenerate = fp.read() != content
 
             if regenerate:

--- a/pibooth/config/parser.py
+++ b/pibooth/config/parser.py
@@ -48,6 +48,9 @@ def desktop_quote(arg):
     meaning there. Reserved characters have to be enclosed in double quotes,
     a few of them being additionally escaped with a backslash.
     """
+    # A literal percent sign is written '%%', quoted or not, else it would be
+    # read as one of the field codes ('%f', '%U', ...) expanded by the launcher
+    arg = arg.replace('%', '%%')
     if not any(char in arg for char in ' \t\n"\'\\><~|&;$*?#()`'):
         return arg
     for char in ('\\', '"', '`', '$'):  # backslash first, it escapes the others

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,25 @@
 # -*- coding: utf-8 -*-
 
+import os
+import sys
+import shutil
 import os.path as osp
 import pytest
+
+from pibooth.config import parser
+from pibooth.config.parser import PiConfigParser, desktop_quote, get_launch_command
+
+
+@pytest.fixture
+def autostart_cfg(cfg_path, tmpdir, monkeypatch):
+    """Return a configuration with autostart enabled, and the path to the
+    auto-startup file it generates in an isolated home directory.
+    """
+    monkeypatch.setenv('HOME', str(tmpdir))
+    monkeypatch.setattr(parser, 'get_launch_command', lambda: '/venv/bin/pibooth')
+    config = PiConfigParser(cfg_path, None)
+    config.set('GENERAL', 'autostart', 'True')
+    return config, tmpdir.join('.config', 'autostart', 'pibooth.desktop')
 
 
 def test_join_path_to_config_directory(cfg):
@@ -65,3 +83,114 @@ def test_string_list_extended(cfg):
     assert cfg.gettuple('PICTURE', 'overlays', str, 1) == ('',)
     assert cfg.gettuple('PICTURE', 'backgrounds', str) == ('fond1.jpg', 'fond2.jpg')
     assert cfg.gettuple('PICTURE', 'backgrounds', str, 3) == ('fond1.jpg', 'fond2.jpg', 'fond2.jpg')
+
+
+@pytest.mark.parametrize('path', ['/usr/local/bin/pibooth', '/home/pi/pibooth-venv/bin/pibooth'])
+def test_desktop_quote_usual_path(path):
+    assert desktop_quote(path) == path
+
+
+def test_desktop_quote_reserved_character():
+    assert desktop_quote('/home/my pi/venv/bin/pibooth') == '"/home/my pi/venv/bin/pibooth"'
+    # A single quote is reserved, but has no special meaning inside the quotes
+    assert desktop_quote("/home/o'pi/venv/bin/pibooth") == '"/home/o\'pi/venv/bin/pibooth"'
+
+
+def test_desktop_quote_escaped_character():
+    assert desktop_quote('/home/a"b/pibooth') == '"/home/a\\"b/pibooth"'
+    assert desktop_quote('/home/a\\b/pibooth') == '"/home/a\\\\b/pibooth"'
+    assert desktop_quote('/home/a`b/pibooth') == '"/home/a\\`b/pibooth"'
+    assert desktop_quote('/home/a$b/pibooth') == '"/home/a\\$b/pibooth"'
+
+
+def test_desktop_quote_percent_sign():
+    # '%' is not reserved: it is doubled, but does not require quotes on its own
+    assert desktop_quote('/home/100%/bin/pibooth') == '/home/100%%/bin/pibooth'
+    assert desktop_quote('/home/100% pi/bin/pibooth') == '"/home/100%% pi/bin/pibooth"'
+
+
+def test_get_launch_command_next_to_interpreter(tmpdir, monkeypatch):
+    script = tmpdir.join('bin', 'pibooth')
+    script.write('', ensure=True)
+    monkeypatch.setattr(sys, 'executable', str(tmpdir.join('bin', 'python')))
+    assert get_launch_command() == str(script)
+
+
+def test_get_launch_command_from_path(tmpdir, monkeypatch):
+    monkeypatch.setattr(sys, 'executable', str(tmpdir.join('bin', 'python')))
+    monkeypatch.setattr(shutil, 'which', lambda name: '/usr/bin/' + name)
+    assert get_launch_command() == '/usr/bin/pibooth'
+
+
+def test_get_launch_command_not_resolved(tmpdir, monkeypatch):
+    monkeypatch.setattr(sys, 'executable', str(tmpdir.join('bin', 'python')))
+    monkeypatch.setattr(shutil, 'which', lambda name: None)
+    assert get_launch_command() == 'pibooth'
+
+
+def test_autostart_file_generated(autostart_cfg):
+    config, desktop_file = autostart_cfg
+    config.handle_autostart()
+    assert desktop_file.read() == ("[Desktop Entry]\n"
+                                   "Name=pibooth\n"
+                                   "Exec=/venv/bin/pibooth\n"
+                                   "Type=application\n")
+
+
+def test_autostart_file_generated_with_delay(autostart_cfg):
+    config, desktop_file = autostart_cfg
+    config.set('GENERAL', 'autostart_delay', '5')
+    config.handle_autostart()
+    assert 'Exec=bash -c "sleep 5 && /venv/bin/pibooth"\n' in desktop_file.read()
+
+
+def test_autostart_file_quotes_path_with_space(autostart_cfg, monkeypatch):
+    config, desktop_file = autostart_cfg
+    monkeypatch.setattr(parser, 'get_launch_command', lambda: '/home/my pi/venv/bin/pibooth')
+    config.handle_autostart()
+    assert 'Exec="/home/my pi/venv/bin/pibooth"\n' in desktop_file.read()
+
+    config.set('GENERAL', 'autostart_delay', '5')
+    config.handle_autostart()
+    # Quoted for the shell inside, for the desktop entry outside
+    assert 'Exec=bash -c "sleep 5 && \'/home/my pi/venv/bin/pibooth\'"\n' in desktop_file.read()
+
+
+def test_autostart_file_regenerated_on_command_change(autostart_cfg, monkeypatch):
+    config, desktop_file = autostart_cfg
+    config.handle_autostart()
+    monkeypatch.setattr(parser, 'get_launch_command', lambda: '/other/venv/bin/pibooth')
+    config.handle_autostart()
+    assert 'Exec=/other/venv/bin/pibooth\n' in desktop_file.read()
+
+
+def test_autostart_file_regenerated_from_bare_command(autostart_cfg):
+    config, desktop_file = autostart_cfg
+    desktop_file.write("[Desktop Entry]\nName=pibooth\nExec=pibooth\nType=application\n", ensure=True)
+    config.handle_autostart()
+    assert 'Exec=/venv/bin/pibooth\n' in desktop_file.read()
+
+
+def test_autostart_file_regenerated_on_delay_prefix_change(autostart_cfg):
+    config, desktop_file = autostart_cfg
+    config.set('GENERAL', 'autostart_delay', '50')
+    config.handle_autostart()
+    config.set('GENERAL', 'autostart_delay', '5')
+    config.handle_autostart()
+    assert 'sleep 5 &&' in desktop_file.read()
+
+
+def test_autostart_file_left_untouched(autostart_cfg):
+    config, desktop_file = autostart_cfg
+    config.handle_autostart()
+    os.utime(str(desktop_file), (0, 0))
+    config.handle_autostart()
+    assert desktop_file.stat().mtime == 0
+
+
+def test_autostart_file_removed(autostart_cfg):
+    config, desktop_file = autostart_cfg
+    config.handle_autostart()
+    config.set('GENERAL', 'autostart', 'False')
+    config.handle_autostart()
+    assert not desktop_file.check()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,8 +12,8 @@ from pibooth.config.parser import PiConfigParser, desktop_quote, get_launch_comm
 
 @pytest.fixture
 def autostart_cfg(cfg_path, tmpdir, monkeypatch):
-    """Return a configuration with autostart enabled, and the path to the
-    auto-startup file it generates in an isolated home directory.
+    """Return a config with autostart enabled and the auto-startup file it
+    generates in an isolated home directory.
     """
     monkeypatch.setenv('HOME', str(tmpdir))
     monkeypatch.setattr(parser, 'get_launch_command', lambda: '/venv/bin/pibooth')
@@ -92,7 +92,6 @@ def test_desktop_quote_usual_path(path):
 
 def test_desktop_quote_reserved_character():
     assert desktop_quote('/home/my pi/venv/bin/pibooth') == '"/home/my pi/venv/bin/pibooth"'
-    # A single quote is reserved, but has no special meaning inside the quotes
     assert desktop_quote("/home/o'pi/venv/bin/pibooth") == '"/home/o\'pi/venv/bin/pibooth"'
 
 
@@ -104,7 +103,6 @@ def test_desktop_quote_escaped_character():
 
 
 def test_desktop_quote_percent_sign():
-    # '%' is not reserved: it is doubled, but does not require quotes on its own
     assert desktop_quote('/home/100%/bin/pibooth') == '/home/100%%/bin/pibooth'
     assert desktop_quote('/home/100% pi/bin/pibooth') == '"/home/100%% pi/bin/pibooth"'
 
@@ -152,7 +150,6 @@ def test_autostart_file_quotes_path_with_space(autostart_cfg, monkeypatch):
 
     config.set('GENERAL', 'autostart_delay', '5')
     config.handle_autostart()
-    # Quoted for the shell inside, for the desktop entry outside
     assert 'Exec=bash -c "sleep 5 && \'/home/my pi/venv/bin/pibooth\'"\n' in desktop_file.read()
 
 


### PR DESCRIPTION
## Problem

`handle_autostart()` wrote `Exec=pibooth`, a bare command name. The desktop session only resolves it if the console script is on *its* PATH: true for a system-wide install (`/usr/local/bin`), false for a virtual environment. In a venv, pibooth silently does not start at boot.

## Changes

In `pibooth/config/parser.py`:

- **`get_launch_command()`** — resolves the console script next to `sys.executable`, which covers both a venv and a system-wide install. Falls back to `shutil.which('pibooth')` when started as `python -m pibooth.booth`, then to the bare name, so behaviour is never worse than before.
- **`desktop_quote()`** — quotes for the desktop-entry `Exec` format, not for a shell. Single quotes have no special meaning there; reserved characters must be enclosed in double quotes with `\`, `"`, `` ` `` and `$` backslash-escaped. Paths without reserved characters stay unquoted, so the common case is unchanged. A literal `%` is doubled, quoted or not, otherwise a launcher reads what follows it as one of the field codes it expands (`%f`, `%U`, ...).
- **Delayed start** — the shell snippet stays a single `bash -c` argument, quoted for the desktop entry outside and with `shlex.quote()` for the shell inside.
- **Regeneration test** — compares the full file content instead of only looking for `sleep <delay>`. A changed executable path is now detected, and so is a delay going from 50 to 5, which the substring test matched.

Resulting `Exec` values:

```
Exec=/usr/local/bin/pibooth
Exec="/home/my pi/venv/bin/pibooth"
Exec=bash -c "sleep 5 && '/home/my pi/venv/bin/pibooth'"
```

## Behaviour change

`~/.config/autostart/pibooth.desktop` is now rewritten whenever its content differs from what the configuration implies. Manual edits to that file are overwritten, where previously they survived as long as the `sleep` delay matched.

## Tests

`tests/test_config.py` covers `desktop_quote()` (usual paths, reserved characters, backslash-escaped characters, percent sign), `get_launch_command()` (its three resolution paths), and the generated file itself through a fixture isolating `HOME` in `tmpdir`: exact content with and without the delay, a path containing a space in both cases, regeneration on a command change, from a legacy `Exec=pibooth` entry and on the 50 → 5 delay change, removal when autostart is disabled, and no rewrite when nothing changed.

`tests/test_config.py` passes 30/30. On the full suite, `tests/test_factory.py` and `tests/test_camera.py` fail identically with and without these changes, for lack of a camera and of a rendering device.

Firing at boot on a Raspberry Pi is not verified here — that needs real hardware.