### PR TITLE
Release 2.1.0

### DIFF
--- a/pibooth/__init__.py
+++ b/pibooth/__init__.py
@@ -2,7 +2,7 @@
 
 """A photo booth application in pure Python for the Raspberry Pi."""
 
-__version__ = "2.0.8"
+__version__ = "2.1.0"
 
 try:
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ def main():
             'Natural Language :: Portuguese',
             'Natural Language :: Portuguese (Brazilian)',
             'Natural Language :: Spanish',
+            'Natural Language :: Swedish',
             'Topic :: Multimedia :: Graphics :: Capture :: Digital Camera',
         ],
         author="Vincent Verdeil, Antoine Rousseaux",


### PR DESCRIPTION
Prepares the 2.1.0 release, the first one since 2.0.8 (July 2023). All the pull requests targeted at this release are merged, #671 being the last one.

## What is in the commit

Two files, nothing else:

- `pibooth/__init__.py` — `__version__ = "2.1.0"`. It is the only place where the version is declared: `setup.py` imports it and the `download_url` is built from it, so the git tag has to match it exactly.
- `setup.py` — adds the `Natural Language :: Swedish` classifier. The Swedish translation was contributed in 2023 (`26eb010`) and `language.py` does hold 12 languages, but the metadata was never updated, so PyPI does not list the language. Remove that line if the release commit should stay strictly limited to the version bump.

## Verification

The release procedure of `docs/sources/dev/release.rst` was run up to and including step 6, everything but the upload:

| Check | Result |
|---|---|
| `python -m build .` | wheel and sdist built as 2.1.0 |
| `twine check --strict dist/*` | PASSED on both |
| wheel installed in a clean virtual environment | OK, reports 2.1.0 |
| `pibooth --reset` on that install | `pibooth.cfg` and `translations.cfg` generated |
| data files shipped | fonts and pictures present |
| dependencies of the wheel | neither `picamera` nor `picamera2`, `Requires-Python >=3.10` |
| `Rpi2Camera` imported from the installed wheel | OK, proxy `None` without a camera |
| test suite | 117 passed, 5 skipped |
| blocking flake8 | 0 |

Two console scripts do not answer `--help` in a bare environment: `pibooth-diag` stops cleanly on *gPhoto2 not installed*, and `pibooth-printcfg` raises on `import cups`. That module level import is unchanged since 2.0.8, so it is not a regression of this release — both scripts belong to the `dslr` and `printer` extras. Worth making those imports optional one day, not here.

## What this pull request does not do

The upload to PyPI is irreversible and a version number can never be reused, so it stays manual: once this is merged, and once the Picamera2 backend is validated on real hardware (Pi 5 and hybrid mode in priority), rebuild the package locally, `twine upload dist/*`, then `git tag 2.1.0 && git push origin 2.1.0` and create the GitHub release.

Release notes are drafted separately, structured like the 2.0.8 ones, with the breaking changes first: `RpiCamera` / `HybridRpiCamera` / `get_rpi_camera_proxy()` replaced by their `Rpi2` counterparts, the Pi Camera effects becoming the PIL filters, and Python 3.10+ now required with 2.0.8 staying the version for Bullseye installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgNy1tCC3nWQZPfjYLwHdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgNy1tCC3nWQZPfjYLwHdA)_